### PR TITLE
Disambiguated typeahead for participants

### DIFF
--- a/public/modules/actions/views/create-action.client.view.html
+++ b/public/modules/actions/views/create-action.client.view.html
@@ -3,7 +3,7 @@
         <h1>New Action</h1>
     </div>
     <div class="col-md-12">
-        <form class="form-horizontal" data-ng-submit="create()" novalidate>
+        <form class="form-horizontal" data-ng-submit="create()" novalidate autocomplete="off">
             <fieldset>
 				<alert data-ng-show="success" data-ng-bind="success" type="success"></alert>
 				<div data-ng-show="error" class="text-danger">
@@ -20,7 +20,7 @@
                 <div class="form-group">
                     <label class="control-label" for="actor">Find actor</label>
                     <div class="controls">
-                        <input id="actor" type="text" autocomplete="off" ng-model="actor" typeahead-editable="false" typeahead-on-select="actor = $item" typeahead="participant.displayName for participant in findParticipants($viewValue)" class="form-control" placeholder="Find actor">
+                        <input id="actor" type="text" autocomplete="off" ng-model="actor" typeahead-editable="false" typeahead-on-select="actor = $item" typeahead="participant.listName() for participant in findParticipants($viewValue)" class="form-control" placeholder="Find actor">
                     </div>
                 </div>
 				<div class="form-group">
@@ -44,7 +44,7 @@
                 <div class="form-group">
                     <label class="control-label" for="match">Find match</label>
                     <div class="controls">
-                        <input type="text" ng-model="selectedMatch" typeahead-editable="false" typeahead-on-select="addMatch(matches, $item)" typeahead="participant.displayName for participant in findParticipants($viewValue)" class="form-control" placeholder="Find match">
+                        <input type="text" ng-model="selectedMatch" typeahead-editable="false" typeahead-on-select="addMatch(matches, $item)" typeahead="participant.listName() for participant in findParticipants($viewValue)" class="form-control" placeholder="Find match">
                     </div>
                 </div>
                 <div class="list-group">

--- a/public/modules/actions/views/edit-action.client.view.html
+++ b/public/modules/actions/views/edit-action.client.view.html
@@ -3,7 +3,7 @@
         <h1>Edit Action</h1>
     </div>
     <div class="col-md-12">
-        <form class="form-horizontal" data-ng-submit="update()" novalidate>
+        <form class="form-horizontal" data-ng-submit="update()" novalidate autocomplete="off">
             <fieldset>
 				<div data-ng-show="error" class="text-danger">
 					<strong data-ng-bind="error"></strong>
@@ -19,7 +19,7 @@
                 <div class="form-group">
                     <label class="control-label" for="actor">Find actor</label>
                     <div class="controls">
-                        <input id="actor" type="text" ng-model="action.actor" typeahead-editable="false" typeahead-on-select="action.actor = $item" typeahead="participant.displayName for participant in findParticipants($viewValue)" class="form-control" placeholder="Find actor">
+                        <input id="actor" type="text" ng-model="action.actor.displayName" typeahead-editable="false" typeahead-on-select="action.actor = $item" typeahead="participant.listName() for participant in findParticipants($viewValue)" class="form-control" placeholder="Find actor">
                     </div>
                 </div>
 				<div class="form-group">
@@ -43,7 +43,7 @@
                 <div class="form-group">
                     <label class="control-label" for="match">Find match</label>
                     <div class="controls">
-                        <input type="text" ng-model="selectedMatch" typeahead-editable="false" typeahead-on-select="addMatch(action.matches, $item)" typeahead="participant.displayName for participant in findParticipants($viewValue)" class="form-control" placeholder="Find match">
+                        <input type="text" ng-model="selectedMatch" typeahead-editable="false" typeahead-on-select="addMatch(action.matches, $item)" typeahead="participant.listName() for participant in findParticipants($viewValue)" class="form-control" placeholder="Find match">
                     </div>
                 </div>
                 <div class="list-group">

--- a/public/modules/participants/services/participants.client.service.js
+++ b/public/modules/participants/services/participants.client.service.js
@@ -3,11 +3,19 @@
 //Participants service used to communicate Participants REST endpoints
 angular.module('participants').factory('Participants', ['$resource',
 	function($resource) {
-		return $resource('participants/:participantId', { participantId: '@_id'
+		var Participant = $resource('participants/:participantId', { participantId: '@_id'
 		}, {
 			update: {
 				method: 'PUT'
 			}
 		});
+		
+		angular.extend(Participant.prototype, {
+			listName: function() {
+				return this.displayName + ' (' + this.phone + ')';
+			}
+		});
+		
+		return Participant;
 	}
 ]);

--- a/public/modules/participations/views/create-participation.client.view.html
+++ b/public/modules/participations/views/create-participation.client.view.html
@@ -4,12 +4,12 @@
     </div>
     
     <div class="col-md-12">
-        <form class="form-horizontal" data-ng-submit="create()" novalidate>
+        <form class="form-horizontal" data-ng-submit="create()" novalidate autocomplete="off">
             <fieldset>
                 <div class="form-group">
                     <label class="control-label" for="name">Find participant</label>
                     <div class="controls">
-                        <input type="text" ng-model="selected" ng-change="attendee = null" typeahead-editable="false" typeahead-on-select="attendee = $item" typeahead="participant.displayName for participant in findParticipants($viewValue)" class="form-control" placeholder="Find participant">
+                        <input type="text" ng-model="selected" ng-change="attendee = null" typeahead-editable="false" typeahead-on-select="attendee = $item" typeahead="participant.listName() for participant in findParticipants($viewValue)" class="form-control" placeholder="Find participant">
                     </div>
                 </div>
 				<div data-ng-show="error" class="text-danger">


### PR DESCRIPTION
There were two problems.

1) The browser autocomplete was putting a list of values on top of the list created
by typeahead.  The form attribute 'autocomplete="off"' is being used to stop this.

2) The participant name was displayed by itself in the list so participants with
the same name could not be distinguished.  Now the list includes the phone number
which is a required field and should be unique, i.e. Anthony Crumley (2059999999).