### PR TITLE
Improved user experience for participant signin

### DIFF
--- a/public/modules/participations/controllers/participations.client.controller.js
+++ b/public/modules/participations/controllers/participations.client.controller.js
@@ -4,6 +4,7 @@
 angular.module('participations').controller('ParticipationsController', ['$scope', '$stateParams', '$location', 'Authentication', 'Participations', 'NetworkEvents', 'Participants',
 	function($scope, $stateParams, $location, Authentication, Participations, NetworkEvents, Participants) {
 		$scope.authentication = Authentication;
+		$scope.isSelectionEditable = false;
 		
 		// Create new Participation
 		$scope.create = function() {
@@ -16,22 +17,19 @@ angular.module('participations').controller('ParticipationsController', ['$scope
 				// Redirect after save
 				participation.$save({ networkEventId: $stateParams.networkEventId }, function(response) {
 					$location.path('network-events/' + $stateParams.networkEventId + '/participations/create');
+					$scope.isSelectionEditable = false; 
+					$scope.error = null;
 	
 					// Clear form fields
 					$scope.selected = null;
-					$scope.attendee.firstName = '';
-					$scope.attendee.lastName = '';
-					$scope.attendee.phone = '';
-					$scope.attendee.email = '';
-					$scope.attendee.identity = '';
-					$scope.attendee.affiliation = '';
+					$scope.attendee = null;
 				}, function(errorResponse) {
 					$scope.error = errorResponse.data.message;
 				});
 			};
 			
 			// If an attendee is selected from existing participants update the attendee
-			if ($scope.attendee._id) {
+			if ($scope.attendee && $scope.attendee._id) {
 				// Update the attendee participant.
 				$scope.attendee.$update(function(response) {
 					saveParticipation(response);
@@ -65,6 +63,36 @@ angular.module('participations').controller('ParticipationsController', ['$scope
 			$scope.networkEvent = NetworkEvents.get({ 
 				networkEventId: $stateParams.networkEventId
 			});
+		};
+		
+		// Clears out the selected participant without saving anything.
+		$scope.clearSelection = function() {
+			$scope.attendee = null; 
+			$scope.selected = null;
+		};
+		
+		// Allows the selected participant to be edited and saved.
+		$scope.editSelection = function() {
+			$scope.isSelectionEditable = true; 
+		};
+		
+		// Called when the attendee name in the typeahead is changed.
+		$scope.onSelectedChange = function() {
+			$scope.attendee = null;
+			$scope.isSelectionEditable = false; 
+		};
+		
+		// Determine if the participant form should be shown to help prevent
+		// accidentally changing information for a participant.
+		$scope.showForm = function(selected, isEditable) {
+			return !selected || isEditable;
+		};
+		
+		// Determine if the selected participants attributes should be shown 
+		// instead of the participant form to help prevent accidental changes
+		// to a participant's information.
+		$scope.showSelectedAttributes = function(selected, isEditable) {
+			return selected && !isEditable;
 		};
 	}
 ]);

--- a/public/modules/participations/tests/participations.client.controller.test.js
+++ b/public/modules/participations/tests/participations.client.controller.test.js
@@ -97,12 +97,7 @@
 			$httpBackend.flush();
 
 			// Test form inputs are reset
-			expect(scope.attendee.firstName).toEqual('');
-			expect(scope.attendee.lastName).toEqual('');
-			expect(scope.attendee.phone).toEqual('');
-			expect(scope.attendee.email).toEqual('');
-			expect(scope.attendee.identity).toEqual('');
-			expect(scope.attendee.affiliation).toEqual('');
+			expect(scope.attendee).toEqual(null);
 
 			// Test URL redirection after the Participation was created
 			expect($location.path()).toBe('/network-events/525a8422f6d0f87f0e407a33/participations/create');

--- a/public/modules/participations/views/create-participation.client.view.html
+++ b/public/modules/participations/views/create-participation.client.view.html
@@ -9,9 +9,43 @@
                 <div class="form-group">
                     <label class="control-label" for="name">Find participant</label>
                     <div class="controls">
-                        <input type="text" ng-model="selected" ng-change="attendee = null" typeahead-editable="false" typeahead-on-select="attendee = $item" typeahead="participant.listName() for participant in findParticipants($viewValue)" class="form-control" placeholder="Find participant">
+                        <input type="text" ng-model="selected" ng-change="onSelectedChange()" typeahead-editable="false" typeahead-on-select="attendee = $item" typeahead="participant.listName() for participant in findParticipants($viewValue)" class="form-control" placeholder="Find participant">
                     </div>
                 </div>
+            </fieldset>
+			<div data-ng-show="showSelectedAttributes(selected, isSelectionEditable)">
+				<h1>
+					<span data-ng-bind="attendee.displayName"></span>
+					<a class="btn btn-lg" data-ng-click="clearSelection()">
+						<i class="glyphicon glyphicon-remove"></i>
+					</a>
+				</h1>
+				<div class="clearfix">
+					<dl class="dl-horizontal">
+					  <dt>Phone</dt>
+					  <dd data-ng-bind="attendee.phone"></dd>
+					  <dt>Email</dt>
+					  <dd data-ng-bind="attendee.email"></dd>
+					  <dt>Identity</dt>
+					  <dd data-ng-bind="attendee.identity"></dd>
+					  <dt>Affiliation</dt>
+					  <dd data-ng-bind="attendee.affiliation"></dd>
+					</dl>
+				</div>
+				<div class="clearfix">
+					<h3>
+						Is this information correct for <span data-ng-bind="attendee.firstName"></span>?
+	                    <button type="submit" class="btn btn-default">Yes, submit.</button>
+	                    <small>
+	                    	or
+							<a data-ng-click="editSelection()">
+								No, edit.
+							</a>
+	                    </small>
+					</h3>
+				</div>
+			</div>
+            <fieldset data-ng-show="showForm(selected, isSelectionEditable)">
 				<div data-ng-show="error" class="text-danger">
 					<strong data-ng-bind="error"></strong>
 				</div>


### PR DESCRIPTION
The previous participant signin was unclear when the volunteer was creating
a participant or editing an existing participant.  It would be easy to accidentally
change one participant to another one.  Now it is a little more clear when
and existing participant is being edited.