### PR TITLE
Initialize database with a user

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,13 @@ This setup uses Cloud9 for your development environment.  Cloud9 provides an onl
   ```
   mkdir /home/ubuntu/workspace/mongo
   mongod --dbpath /home/ubuntu/workspace/mongo --smallfiles --fork --logpath /home/ubuntu/workspace/mongo/mongod.log
+  grunt initdb
   ```
   * In the bash tab, start the application by entering the following command:
   ```
   grunt
   ```
-  * To view the app in the browser, select Preview from the editor menu and then select Preview Running Application.  This will open the application in a tab of the editor.
+  * To view the app in the browser, select Preview from the editor menu and then select Preview Running Application.  This will open the application in a tab of the editor.  Log into the application with username `janedoe` and password `password`.
 * Hack away
 * Send lots of pull requests!!
 * In order to get updates from the main project use the following command in the bash tab:

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -141,6 +141,11 @@ module.exports = function(grunt) {
 			}
 		},
 		shell: {
+			initdb: {
+				/* jshint ignore:start */
+				command: 'mongo network-dev --eval \'db.users.insert({ "salt" : "\\u0019�\\u001cE�־��܂TZG��", "displayName" : "Jane Doe", "provider" : "local", "username" : "janedoe", "created" : ISODate("2015-08-20T14:33:40.135Z"), "roles" : [ "user", "admin" ], "password" : "WBA78SQ77XMCq3FW4QA+NKEuxnbs1SLc2fS06TOI6LHdetcu4UXjbWrmFkh7/cRFvacT4ke9AigmoUF56Y0X8w==", "email" : "jane@doe.com", "lastName" : "Doe", "firstName" : "Jane", "__v" : 0 })\''
+				/* jshint ignore:end */
+			},
     		mongodb: {
         		command: 'mongod --dbpath /home/ubuntu/workspace/mongo --smallfiles --fork --logpath /home/ubuntu/workspace/mongo/mongod.log',
 	        	options: {
@@ -188,6 +193,9 @@ module.exports = function(grunt) {
 
 	// Test task.
 	grunt.registerTask('test', ['env:test', 'mochaTest', 'karma:unit']);
+	
+	// Initialize mongo db for development.
+	grunt.registerTask('initdb', ['shell:initdb']);
 	
 	// Launch mongo db.
 	grunt.registerTask('mongo', ['shell:mongodb']);


### PR DESCRIPTION
Once the development environment is setup, people are not able to
log into the application because no user exists.  A grunt command
has been created to initialize the database with in initial user.

The command is:
    $ grunt initdb

The result will be a user with the username "janedoe" and password
"password".