### PR TITLE
Disable autofill of password on certain forms (fix for issue #133) 

### DIFF
--- a/public/modules/users/views/create-user.client.view.html
+++ b/public/modules/users/views/create-user.client.view.html
@@ -4,6 +4,10 @@
     </div>
     <div class="col-md-12">
         <form class="form-horizontal" data-ng-submit="create()" novalidate autocomplete="off">
+        	<!-- dummy fields to prevent browser from auto-filling the username/password on this form -->
+			<input type="text" style="display: none" id="fakeUsername" name="fakeUsername" value="" />
+			<input type="password" style="display: none" id="fakePassword" name="fakePassword" value="" />
+        	
             <fieldset>
 				<alert data-ng-show="error" data-ng-bind="error" type="danger"></alert>
 				<div class="form-group">

--- a/public/modules/users/views/create-user.client.view.html
+++ b/public/modules/users/views/create-user.client.view.html
@@ -4,7 +4,7 @@
     </div>
     <div class="col-md-12">
         <form class="form-horizontal" data-ng-submit="create()" novalidate autocomplete="off">
-        	<!-- dummy fields to prevent browser from auto-filling the username/password on this form -->
+			<!-- dummy fields to prevent browser from auto-filling the username/password on this form -->
 			<input type="text" style="display: none" id="fakeUsername" name="fakeUsername" value="" />
 			<input type="password" style="display: none" id="fakePassword" name="fakePassword" value="" />
         	

--- a/public/modules/users/views/settings/change-password.client.view.html
+++ b/public/modules/users/views/settings/change-password.client.view.html
@@ -2,7 +2,7 @@
 	<h3 class="col-md-12 text-center">Change your password</h3>
 	<div class="col-xs-offset-2 col-xs-8 col-md-offset-5 col-md-2">
 		<form data-ng-submit="changeUserPassword()" class="signin form-horizontal" autocomplete="off">
-        	<!-- dummy fields to prevent browser from auto-filling the username/password on this form -->
+			<!-- dummy fields to prevent browser from auto-filling the username/password on this form -->
 			<input type="password" style="display: none" id="fakePassword" name="fakePassword" value="" />
 			
 			<fieldset>

--- a/public/modules/users/views/settings/change-password.client.view.html
+++ b/public/modules/users/views/settings/change-password.client.view.html
@@ -2,6 +2,9 @@
 	<h3 class="col-md-12 text-center">Change your password</h3>
 	<div class="col-xs-offset-2 col-xs-8 col-md-offset-5 col-md-2">
 		<form data-ng-submit="changeUserPassword()" class="signin form-horizontal" autocomplete="off">
+        	<!-- dummy fields to prevent browser from auto-filling the username/password on this form -->
+			<input type="password" style="display: none" id="fakePassword" name="fakePassword" value="" />
+			
 			<fieldset>
 				<div class="form-group">
 					<label for="currentPassword">Current Password</label>


### PR DESCRIPTION
Added dummy hidden inputs for username and password to forms where the browser shouldn't autofill those values.

This work connects to #133 