### PR TITLE
Fix Recruiter Needed error on signin

### DIFF
--- a/app/models/member.server.model.js
+++ b/app/models/member.server.model.js
@@ -31,7 +31,7 @@ var MemberSchema = Participant.discriminator('Member', new Schema({
 	},
 	shirtSize: {
 		type: String,
-		required: 'Please choose a shirt size'
+		default: ''
 	},
 	shirtReceived: {
 		type: Boolean,
@@ -40,7 +40,7 @@ var MemberSchema = Participant.discriminator('Member', new Schema({
 	talent: {
 		type: String,
 		trim: true,
-		required: 'Please provide a talent/passion.'
+		default: ''
 	},
 	placeOfWorship: {
 		type: String,
@@ -49,7 +49,7 @@ var MemberSchema = Participant.discriminator('Member', new Schema({
 	},
 	recruitment: {
 		type: String,
-		required: 'Please provide a recruiter.'
+		default: ''
 	},
 	communityNetworks: {
 		type: String,

--- a/app/tests/member.server.model.test.js
+++ b/app/tests/member.server.model.test.js
@@ -112,7 +112,7 @@ describe('Member Model Unit Tests:', function() {
 			member.shirtSize = '';
 
 			return member.save(function(err) {
-				should.exist(err);
+				should.not.exist(err);
 				done();
 			});
 		});
@@ -121,7 +121,7 @@ describe('Member Model Unit Tests:', function() {
 			member.talent = '';
 
 			return member.save(function(err) {
-				should.exist(err);
+				should.not.exist(err);
 				done();
 			});
 		});
@@ -130,7 +130,7 @@ describe('Member Model Unit Tests:', function() {
 			member.recruitment = '';
 
 			return member.save(function(err) {
-				should.exist(err);
+				should.not.exist(err);
 				done();
 			});
 		});


### PR DESCRIPTION
What a participant is being signed into an event, if the participant
is also a member that was imported without the required fields then
an error will occur saving the participant that will prevent them
from being signed in.

To resolve the problem with a quick fix, the required member fields
have been made optional.  In the future we will need a more robust
solution.