### PR TITLE
Changed the order of the name and metadata labels on the entity list pages

### DIFF
--- a/public/modules/actions/views/list-actions.client.view.html
+++ b/public/modules/actions/views/list-actions.client.view.html
@@ -20,6 +20,9 @@
     </div>
     <div class="list-group">
         <div data-ng-repeat="action in actions" class="list-group-item">
+			<a  class="list-group-item-text"  data-ng-href="#!/actions/{{action._id}}">
+				<h4 class="list-group-item-heading" data-ng-bind="action.description" ></h4>
+			</a>
 			<span ng-class="{'Green':'bg-success', 'Yellow':'bg-warning', 'Red':'bg-danger'}[action.status]">
 			<small class="list-group-item-text">
 				Type: 
@@ -39,9 +42,6 @@
 				<span data-ng-bind="action.status"></span>
 			</small>
 			</span>
-			<a  class="list-group-item-text"  data-ng-href="#!/actions/{{action._id}}">
-				<h4 class="list-group-item-heading" data-ng-bind="action.description" ></h4>
-			</a>
         </div>
     </div>
     <div class="alert alert-warning text-center" data-ng-hide="location || connector || !actions.$resolved || actions.length">

--- a/public/modules/locations/views/list-locations.client.view.html
+++ b/public/modules/locations/views/list-locations.client.view.html
@@ -4,15 +4,15 @@
     </div>
     <div class="list-group">
         <div data-ng-repeat="location in locations" class="list-group-item">
+			<a  class="list-group-item-text" data-ng-href="#!/locations/{{location._id}}">
+				<h4 class="list-group-item-heading" data-ng-bind="location.name"></h4>
+			</a>
 			<small class="list-group-item-text">
 				Created:
 				<span data-ng-bind="location.created | date:'medium'"></span>
 				| By:
 				<span data-ng-bind="location.user.displayName"></span>
 			</small>
-			<a  class="list-group-item-text" data-ng-href="#!/locations/{{location._id}}">
-				<h4 class="list-group-item-heading" data-ng-bind="location.name"></h4>
-			</a>
         </div>
     </div>
     <div class="alert alert-warning text-center" data-ng-hide="!locations.$resolved || locations.length">

--- a/public/modules/members/views/list-members.client.view.html
+++ b/public/modules/members/views/list-members.client.view.html
@@ -7,6 +7,9 @@
 	</div>
     <div class="list-group">
         <div data-ng-repeat="member in members | filter:shirtFilter" class="list-group-item">
+			<a data-ng-href="#!/members/{{member._id}}" class="list-group-item-text">
+				<h4 class="list-group-item-heading" data-ng-bind="member.displayName"></h4>
+			</a>
 			<small class="list-group-item-text">
 			    Phone:
 			    <span data-ng-bind="member.phone"></span>
@@ -19,9 +22,6 @@
 				| Received Shirt:
 				<span data-ng-bind="member.shirtReceived" data-ng-click="giveShirt(member)"></span>
 			</small>
-			<a data-ng-href="#!/members/{{member._id}}" class="list-group-item-text">
-				<h4 class="list-group-item-heading" data-ng-bind="member.displayName"></h4>
-			</a>
         </div>
     </div>
     <div class="alert alert-warning text-center" data-ng-hide="!members.$resolved || members.length">

--- a/public/modules/network-events/views/list-network-events.client.view.html
+++ b/public/modules/network-events/views/list-network-events.client.view.html
@@ -4,6 +4,9 @@
     </div>
     <div class="list-group">
         <div data-ng-repeat="networkEvent in networkEvents" class="list-group-item">
+			<a  class="list-group-item-text" data-ng-href="#!/network-events/{{networkEvent._id}}">
+				<h4 class="list-group-item-heading" data-ng-bind="networkEvent.name"></h4>
+			</a>
 			<small class="list-group-item-text">
 				Creator:
 				<span data-ng-bind="networkEvent.user.displayName"></span>
@@ -14,9 +17,6 @@
 				| Type:
 				<span data-ng-bind="networkEvent.eventType"></span>
 			</small>
-			<a  class="list-group-item-text" data-ng-href="#!/network-events/{{networkEvent._id}}">
-				<h4 class="list-group-item-heading" data-ng-bind="networkEvent.name"></h4>
-			</a>
         </div>
     </div>
     <div class="alert alert-warning text-center" data-ng-hide="!networkEvents.$resolved || networkEvents.length">

--- a/public/modules/participants/views/list-participants.client.view.html
+++ b/public/modules/participants/views/list-participants.client.view.html
@@ -4,6 +4,9 @@
     </div>
     <div class="list-group">
         <div data-ng-repeat="participant in participants"  class="list-group-item">
+			<a  class="list-group-item-text"  data-ng-href="#!/participants/{{participant._id}}">
+				<h4 class="list-group-item-heading" data-ng-bind="participant.displayName"></h4>
+			</a>
 			<small class="list-group-item-text">
 			    Phone:
 				<span data-ng-bind="participant.phone"></span>
@@ -12,9 +15,6 @@
 				| Participant is a: 
 				<span data-ng-bind="participant.identity"></span>
 			</small>
-			<a  class="list-group-item-text"  data-ng-href="#!/participants/{{participant._id}}">
-				<h4 class="list-group-item-heading" data-ng-bind="participant.displayName"></h4>
-			</a>
         </div>
     </div>
     <div class="alert alert-warning text-center" data-ng-hide="!participants.$resolved || participants.length">

--- a/public/modules/users/views/list-users.client.view.html
+++ b/public/modules/users/views/list-users.client.view.html
@@ -4,6 +4,9 @@
     </div>
     <div class="list-group">
         <div data-ng-repeat="user in users" class="list-group-item">
+			<a  class="list-group-item-text" data-ng-href="#!/users/{{user._id}}">
+				<h4 class="list-group-item-heading" data-ng-bind="user.displayName"></h4>
+			</a>
 			<small class="list-group-item-text">
 			    User Name:
 			    <span data-ng-bind="user.username"></span>
@@ -14,9 +17,6 @@
 				Created:
 				<span data-ng-bind="user.created | date:'shortDate'"></span>
 			</small>
-			<a  class="list-group-item-text" data-ng-href="#!/users/{{user._id}}">
-				<h4 class="list-group-item-heading" data-ng-bind="user.displayName"></h4>
-			</a>
         </div>
     </div>
     <div class="alert alert-warning text-center" data-ng-hide="!users.$resolved || users.length">


### PR DESCRIPTION
Moved the name of the element for each row on the list pages above the metadata that describes it.

This work connects to #162 