### PR TITLE
Changed startup script to use curl to check for running app.

### DIFF
--- a/app/controllers/status.server.controller.js
+++ b/app/controllers/status.server.controller.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+var mongoose = require('mongoose'),
+	errorHandler = require('./errors.server.controller'),
+	_ = require('lodash');
+
+/**
+ * Create a Participant
+ */
+exports.check = function(req, res) {
+	res.send('OK');	
+};

--- a/app/routes/status.server.routes.js
+++ b/app/routes/status.server.routes.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = function(app) {
+	var status = require('../../app/controllers/status.server.controller');
+
+    // Participants Routes
+    app.route('/status')
+    	.get(status.check);
+};

--- a/startup
+++ b/startup
@@ -2,6 +2,7 @@
 MONPATH="/home/ubuntu/workspace/mongo"
 LOGFILE="$MONPATH/mongod.log"
 ISNEW="0"
+DOMAIN="http://localhost:8080/status"
 
 echo "Checking for mongo installation."
 if [ ! -d $MONPATH ];
@@ -26,12 +27,12 @@ if [ "$ISNEW" = "1" ]; then
 fi
 
 echo "Checking for existing instance of Network."
-GRUNTRUN="$(pidof grunt | wc -l)"
-if [ "$GRUNTRUN" = 0 ]; then
+GRUNTRUN="$(curl $DOMAIN 2> /dev/null)"
+if [ "$GRUNTRUN" = "OK" ]; then
+    echo "The Network is already running."
+else
     echo "Starting Network."
     grunt
-else
-    echo "The Network is already running."
 fi
 
 exit 0


### PR DESCRIPTION
Curl appears to come with the default Cloud9 installation. Checking the new /status route allows the script to not stop if other grunt processes are being run. Solves #192 