### PR TITLE
Fixed error converting participant to a member

### DIFF
--- a/public/modules/members/views/create-member.client.view.html
+++ b/public/modules/members/views/create-member.client.view.html
@@ -9,6 +9,12 @@
     <div class="col-md-12">
         <form class="form-horizontal" data-ng-submit="create()" novalidate autocomplete="off">
             <fieldset>
+                 <div class="form-group">
+                    <label class="control-label" for="name">Find participant</label>
+                    <div class="controls">
+                        <input id="participant" type="text" ng-model="selected" ng-change="member = null" typeahead-editable="false" typeahead-on-select="selectMember($item)" typeahead="participant.displayName for participant in findParticipants($viewValue)" class="form-control" placeholder="Find participant">
+                    </div>
+                </div>
 				<ng-include src="'/modules/members/views/member-form.client.view.html'"></ng-include>
                 <div class="form-group">
                     <input type="submit" class="btn btn-default">

--- a/public/modules/members/views/member-form.client.view.html
+++ b/public/modules/members/views/member-form.client.view.html
@@ -3,12 +3,6 @@
  		<li data-ng-repeat="message in errorMessages.slice().reverse()">{{message}}</li>
  	</ul>
  </alert>
- <div class="form-group">
-    <label class="control-label" for="name">Find participant</label>
-    <div class="controls">
-        <input id="participant" type="text" ng-model="selected" ng-change="member = null" typeahead-editable="false" typeahead-on-select="selectMember($item)" typeahead="participant.displayName for participant in findParticipants($viewValue)" class="form-control" placeholder="Find participant">
-    </div>
-</div>
 <div class="form-group" data-ng-class="errorStatus.firstName">
 	<label class="control-label" for="firstName">First Name</label>
     <div class="controls">


### PR DESCRIPTION
When the member form was extracted from the create and edit pages, the
participant quick search was inadvertantly included in the form.  It
should have remained in the create page only.  The result was the
upgrading a participant that was searched for would fail to populate
the form fields and would cause a problem saving the member.