### PR TITLE
Changed member autocomplete to always return some members

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -13,7 +13,7 @@ class Member < ActiveRecord::Base
         conditions.where([condition, search: "#{term}%"])
       end
     else
-      none
+      all
     end
   end
   


### PR DESCRIPTION
Initally the member autocomplete would say no items found.  Now it will return
a limited 25 members.