### PR TITLE
Fixed graduating class edit on members

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -76,6 +76,6 @@ class MembersController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def member_params
-      params.require(:member).permit(:first_name, :last_name, :phone, :email, :identity, :affiliation, :address, :city, :state, :zip_code, :shirt_size, :shirt_received, :talent, :place_of_worship, :recruitment, :community_networks, :extra_groups, :other_networks, :graduation_year, :organization_ids => [])
+      params.require(:member).permit(:first_name, :last_name, :phone, :email, :identity, :affiliation, :address, :city, :state, :zip_code, :shirt_size, :shirt_received, :talent, :place_of_worship, :recruitment, :community_networks, :extra_groups, :other_networks, :graduating_class_id, :organization_ids => [])
     end
 end

--- a/app/views/cohorts/show.html.erb
+++ b/app/views/cohorts/show.html.erb
@@ -10,7 +10,7 @@
   <h1>Show cohort</h1>
 </div>
 
-<dl class="dl-horizontal">
+<dl class="dl-horizontal text-left">
   <dt>Name:</dt>
   <dd><%= @cohort.name %></dd>
 

--- a/app/views/graduating_classes/show.html.erb
+++ b/app/views/graduating_classes/show.html.erb
@@ -10,7 +10,7 @@
   <h1>Show graduating class</h1>
 </div>
 
-<dl class="dl-horizontal">
+<dl class="dl-horizontal text-left">
   <dt>Year:</dt>
   <dd><%= @graduating_class.year %></dd>
 

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -10,7 +10,7 @@
   <h1>Show location</h1>
 </div>
 
-<dl class="dl-horizontal">
+<dl class="dl-horizontal text-left">
   <dt>Name:</dt>
   <dd><%= @location.name %></dd>
   

--- a/app/views/members/_form.html.erb
+++ b/app/views/members/_form.html.erb
@@ -52,20 +52,20 @@
     </div>
   </div>
   <div class="form-group">
-    <%= f.label :Organizations, class: "col-sm-2 control-label" %>
+    <%= f.label :organization_ids, 'Organizations', class: "col-sm-2 control-label" %>
     <div class="col-sm-10">
       <%= f.collection_select :organization_ids,
             Organization.order(:name).all,
             :id,
             :name,
-            {:include_blank =>'None'},
+            {:include_blank => 'None'},
             {multiple: true, class: "select2 form-control"} %>
     </div>
   </div>
   <div class='form-group'>
-    <%= f.label :graduation_year, class: "col-sm-2 control-label" %>
+    <%= f.label :graduating_class_id, class: "col-sm-2 control-label" %>
     <div class="col-sm-10">
-      <%= f.collection_select :graduating_class,
+      <%= f.collection_select :graduating_class_id,
             GraduatingClass.order(:year).all,
             :id,
             :year,

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -10,7 +10,7 @@
   <h1>Show member</h1>
 </div>
 
-<dl class="dl-horizontal">
+<dl class="dl-horizontal text-left">
   <dt>First name:</dt>
   <dd><%= @member.first_name %></dd>
 

--- a/app/views/network_actions/show.html.erb
+++ b/app/views/network_actions/show.html.erb
@@ -10,7 +10,7 @@
   <h1>Show action</h1>
 </div>
 
-<dl class="dl-horizontal">
+<dl class="dl-horizontal text-left">
   <dt>Event:</dt>
   <dd><%= link_to @network_action.network_event.try(:name), @network_action.network_event %></dd>
 

--- a/app/views/network_events/show.html.erb
+++ b/app/views/network_events/show.html.erb
@@ -10,7 +10,7 @@
   <h1>Show event</h1>
 </div>
 
-<dl class="dl-horizontal">
+<dl class="dl-horizontal text-left">
   <dt>Name:</dt>
   <dd><%= @network_event.name %></dd>
 

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -10,7 +10,7 @@
   <h1>Show organization</h1>
 </div>
 
-<dl class="dl-horizontal">
+<dl class="dl-horizontal text-left">
   <dt>Name:</dt>
   <dd><%= @organization.name %></dd>
 

--- a/app/views/programs/show.html.erb
+++ b/app/views/programs/show.html.erb
@@ -10,7 +10,7 @@
   <h1>Show program</h1>
 </div>
 
-<dl class="dl-horizontal">
+<dl class="dl-horizontal text-left">
   <dt>Name:</dt>
   <dd><%= @program.name %></dd>
   

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -10,7 +10,7 @@
   <h1>Show school</h1>
 </div>
 
-<dl class="dl-horizontal">
+<dl class="dl-horizontal text-left">
   <dt>Name:</dt>
   <dd><%= @school.name %></dd>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,7 +6,7 @@
   <h1>Show user</h1>
 </div>
 
-<dl class="dl-horizontal">
+<dl class="dl-horizontal text-left">
   <dt>Email:</dt>
   <dd><%= @user.email %></dd>
 


### PR DESCRIPTION
* The graduating class would not save on member edit because the
name of the select needed to be the same as the foreign key.

* Also made a layout change for show pages that caused the field name
and field value to be close together.  They were so far apart it was
hard to connect them sometimes.