### PR TITLE
Add validation to prevent duplicate records

### DIFF
--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -1,5 +1,6 @@
 class Cohort < ActiveRecord::Base
 	validates :name, presence: true
+  validates_uniqueness_of :name
   belongs_to :user
   has_many :cohortians
   has_many :cohorts, through: :cohortians

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,5 +1,6 @@
 class Location < ActiveRecord::Base
   validates :name, presence: true
+  validates_uniqueness_of :name
   
   belongs_to :user
 end

--- a/app/models/neighborhood.rb
+++ b/app/models/neighborhood.rb
@@ -1,5 +1,6 @@
 class Neighborhood < ActiveRecord::Base
   validates :name, presence: true
+  validates_uniqueness_of :name
   
   belongs_to :user
   

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,5 +1,6 @@
 class Organization < ActiveRecord::Base
   validates :name, presence: true
+  validates_uniqueness_of :name
 
   belongs_to :created_by, class_name: "User", foreign_key: :created_by_id
   has_many :affiliations

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -1,5 +1,6 @@
 class Program < ActiveRecord::Base
   	validates :name, presence: true
+    validates_uniqueness_of :name
     has_many :network_events 
     belongs_to :user
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,5 +1,6 @@
 class School < ActiveRecord::Base
   validates :name, presence: true
+  validates_uniqueness_of :name
   
   belongs_to :user
 end

--- a/test/controllers/cohorts_controller_test.rb
+++ b/test/controllers/cohorts_controller_test.rb
@@ -21,7 +21,7 @@ class CohortsControllerTest < ActionController::TestCase
 
   test "should create cohort" do
     assert_difference('Cohort.count') do
-      post :create, cohort: { name: @cohort.name }
+      post :create, cohort: { name: @cohort.name + 'test' }
     end
 
     assert_redirected_to cohort_path(assigns(:cohort))
@@ -38,7 +38,7 @@ class CohortsControllerTest < ActionController::TestCase
   end
 
   test "should update cohort" do
-    patch :update, id: @cohort, cohort: { name: @cohort.name }
+    patch :update, id: @cohort, cohort: { name: @cohort.name + 'test' }
     assert_redirected_to cohort_path(assigns(:cohort))
   end
 

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -21,7 +21,7 @@ class LocationsControllerTest < ActionController::TestCase
 
   test "should create location" do
     assert_difference('Location.count') do
-      post :create, location: { name: @location.name }
+      post :create, location: { name: @location.name + 'test' }
     end
 
     assert_redirected_to location_path(assigns(:location))
@@ -38,7 +38,7 @@ class LocationsControllerTest < ActionController::TestCase
   end
 
   test "should update location" do
-    patch :update, id: @location, location: { name: @location.name }
+    patch :update, id: @location, location: { name: @location.name + 'test' }
     assert_redirected_to location_path(assigns(:location))
   end
 

--- a/test/controllers/neighborhoods_controller_test.rb
+++ b/test/controllers/neighborhoods_controller_test.rb
@@ -21,7 +21,7 @@ class NeighborhoodsControllerTest < ActionController::TestCase
 
   test "should create neighborhood" do
     assert_difference('Neighborhood.count') do
-      post :create, neighborhood: { name: @neighborhood.name }
+      post :create, neighborhood: { name: @neighborhood.name + 'test' }
     end
 
     assert_redirected_to neighborhood_path(assigns(:neighborhood))
@@ -38,7 +38,7 @@ class NeighborhoodsControllerTest < ActionController::TestCase
   end
 
   test "should update neighborhood" do
-    patch :update, id: @neighborhood, neighborhood: { name: @neighborhood.name }
+    patch :update, id: @neighborhood, neighborhood: { name: @neighborhood.name + 'test'}
     assert_redirected_to neighborhood_path(assigns(:neighborhood))
   end
 

--- a/test/controllers/organizations_controller_test.rb
+++ b/test/controllers/organizations_controller_test.rb
@@ -21,7 +21,7 @@ class OrganizationsControllerTest < ActionController::TestCase
 
   test "should create organization" do
     assert_difference('Organization.where(created_by_id: users(:one).id).count') do
-      post :create, organization: { name: @organization.name }
+      post :create, organization: { name: @organization.name + 'test' }
     end
 
     assert_redirected_to organization_path(assigns(:organization))
@@ -38,7 +38,7 @@ class OrganizationsControllerTest < ActionController::TestCase
   end
 
   test "should update organization" do
-    patch :update, id: @organization, organization: { name: @organization.name }
+    patch :update, id: @organization, organization: { name: @organization.name + 'test' }
     assert_redirected_to organization_path(assigns(:organization))
   end
 

--- a/test/controllers/programs_controller_test.rb
+++ b/test/controllers/programs_controller_test.rb
@@ -21,7 +21,7 @@ class ProgramsControllerTest < ActionController::TestCase
 
   test "should create program" do
     assert_difference('Program.count') do
-      post :create, program: { name: @program.name, user_id: @program.user_id }
+      post :create, program: { name: @program.name + 'test', user_id: @program.user_id }
     end
 
     assert_redirected_to program_path(assigns(:program))
@@ -38,7 +38,7 @@ class ProgramsControllerTest < ActionController::TestCase
   end
 
   test "should update program" do
-    patch :update, id: @program, program: { name: @program.name, user_id: @program.user_id }
+    patch :update, id: @program, program: { name: @program.name + 'test', user_id: @program.user_id }
     assert_redirected_to program_path(assigns(:program))
   end
 

--- a/test/controllers/schools_controller_test.rb
+++ b/test/controllers/schools_controller_test.rb
@@ -21,7 +21,7 @@ class SchoolsControllerTest < ActionController::TestCase
 
   test "should create school" do
     assert_difference('School.count') do
-      post :create, school: { name: @school.name }
+      post :create, school: { name: @school.name + 'test' }
     end
 
     assert_redirected_to school_path(assigns(:school))
@@ -38,7 +38,7 @@ class SchoolsControllerTest < ActionController::TestCase
   end
 
   test "should update school" do
-    patch :update, id: @school, school: { name: @school.name }
+    patch :update, id: @school, school: { name: @school.name + 'test' }
     assert_redirected_to school_path(assigns(:school))
   end
 


### PR DESCRIPTION
Altered admin class models to ensure that records with duplicate
names won't be saved. Also, fixed tests to reflect this. Connects to #349.