### PR TITLE
Add mongo id to the members table

### DIFF
--- a/db/migrate/20161116174039_add_mongo_id_to_member.rb
+++ b/db/migrate/20161116174039_add_mongo_id_to_member.rb
@@ -1,0 +1,5 @@
+class AddMongoIdToMember < ActiveRecord::Migration
+  def change
+    add_column :members, :mongo_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160824212724) do
+ActiveRecord::Schema.define(version: 20161116174039) do
 
   create_table "affiliations", force: :cascade do |t|
     t.integer  "member_id"
@@ -115,6 +115,7 @@ ActiveRecord::Schema.define(version: 20160824212724) do
     t.datetime "updated_at",          null: false
     t.integer  "graduating_class_id"
     t.integer  "school_id"
+    t.string   "mongo_id"
   end
 
   create_table "neighborhoods", force: :cascade do |t|


### PR DESCRIPTION
The original database was in MongoDB.  The new database is in Postgres.
When migrating data from MongoDB to Postgres we want to keep up with
the original MongoDB unique identifier for each member so that relation-
ships can be maintained to other entities such as network events.