### PR TITLE
Add transportation checkbox, datetimepicker

### DIFF
--- a/app/assets/javascripts/network_events.coffee
+++ b/app/assets/javascripts/network_events.coffee
@@ -1,3 +1,11 @@
 $(document).on 'ready page:load', ->
   client = new ZeroClipboard($('.copy_button'))
   $('.copy_button').tooltip()
+  checked = $('#network_event_needs_transport').is(':checked')
+  if checked
+    $('#order_div').show()
+  else
+    $('#order_div').hide()
+  $('#network_event_needs_transport').change ->
+    $('#order_div').slideToggle()
+      

--- a/app/controllers/network_events_controller.rb
+++ b/app/controllers/network_events_controller.rb
@@ -151,6 +151,8 @@ class NetworkEventsController < ApplicationController
         :location_id, 
         :scheduled_at, 
         :duration, 
+        :needs_transport, 
+        :transport_ordered_on,
         :organization_ids => [], 
         :site_contact_ids => [],
         :school_contact_ids => [],

--- a/app/views/network_events/_form.html.erb
+++ b/app/views/network_events/_form.html.erb
@@ -144,6 +144,18 @@
     </div>
   </div>
   <div class="form-group">
+    <%= f.label :needs_transport, 'Transportation Needed',  class: "col-sm-2 control-label" %>
+    <div class="col-sm-10">
+      <%= f.check_box :needs_transport, class: "form-control"%>
+    </div>
+  </div>
+  <div class="form-group" id='order_div'>
+    <%= f.label :transport_ordered_on, 'Transportation Ordered', class: "col-sm-2 control-label" %>
+    <div class="col-sm-10">
+      <%= f.datetime_select :transport_ordered_on, class: "form-control" %>
+    </div>
+  </div>
+  <div class="form-group">
     <div class="col-sm-offset-2 col-sm-10">
       <%= f.submit event_button_name(f.object), class: "btn btn-primary" %>
       <% if controller.action_name == 'new' %>

--- a/app/views/network_events/show.html.erb
+++ b/app/views/network_events/show.html.erb
@@ -88,7 +88,13 @@
 
   <dt>Ends At:</dt>
   <dd><%= @network_event.scheduled_at + @network_event.duration.minutes %></dd>
+  
+  <dt>Transportation needed:</dt>
+  <dd><%= @network_event.needs_transport %></dd>
 
+  <dt>Transportation ordered:</dt>
+  <dd><%= @network_event.transport_ordered_on %></dd>
+  
   <dt>Creator:</dt>
   <dd><%= @network_event.user.try(:email) %></dd>
 

--- a/db/migrate/20161130192947_add_fields_to_network_events.rb
+++ b/db/migrate/20161130192947_add_fields_to_network_events.rb
@@ -1,0 +1,6 @@
+class AddFieldsToNetworkEvents < ActiveRecord::Migration
+  def change
+    add_column :network_events, :needs_transport, :boolean
+    add_column :network_events, :transport_ordered_on, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161116174039) do
+ActiveRecord::Schema.define(version: 20161130192947) do
 
   create_table "affiliations", force: :cascade do |t|
     t.integer  "member_id"
@@ -140,10 +140,12 @@ ActiveRecord::Schema.define(version: 20161116174039) do
     t.integer  "location_id"
     t.datetime "scheduled_at"
     t.integer  "user_id"
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
     t.integer  "program_id"
-    t.integer  "duration",     default: 60
+    t.integer  "duration",             default: 60
+    t.boolean  "needs_transport"
+    t.datetime "transport_ordered_on"
   end
 
   add_index "network_events", ["program_id"], name: "index_network_events_on_program_id"


### PR DESCRIPTION
Add 2 fields. A checkbox to mark whether event needs transportation
and a datetimepicker to mark when transportation was ordered. Added
coffeescript to hide datetimepicker based on checkbox value. Connects to #397.