### PR TITLE
Added Letsencrypt for SSL/TLS certificate creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,12 @@ gem 'zeroclipboard-rails'
 # Network Gems
 gem 'devise'
 
+# Until the new API calls are generally available, we must manually specify a 
+# fork of the Heroku API gem:
+gem 'platform-api', github: 'jalada/platform-api', branch: 'master'
+
+gem 'letsencrypt-rails-heroku', group: 'production'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,16 @@
+GIT
+  remote: git://github.com/jalada/platform-api.git
+  revision: 45ddb3c1a7e2c7f85d979c0791db18e99affb237
+  branch: master
+  specs:
+    platform-api (0.8.0)
+      heroics (~> 0.0.17)
+
 GEM
   remote: https://rubygems.org/
   specs:
+    acme-client (0.4.1)
+      faraday (~> 0.9, >= 0.9.1)
     actionmailer (4.2.5)
       actionpack (= 4.2.5)
       actionview (= 4.2.5)
@@ -67,9 +77,18 @@ GEM
       responders
       warden (~> 1.2.3)
     erubis (2.7.0)
+    excon (0.54.0)
     execjs (2.7.0)
+    faraday (0.10.0)
+      multipart-post (>= 1.2, < 3)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
+    heroics (0.0.17)
+      erubis (~> 2.0)
+      excon
+      moneta
+      multi_json (>= 1.9.2)
+      netrc
     i18n (0.7.0)
     jbuilder (2.5.0)
       activesupport (>= 3.0.0, < 5.1)
@@ -82,6 +101,9 @@ GEM
     kaminari (0.17.0)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
+    letsencrypt-rails-heroku (0.3.0)
+      acme-client (~> 0.4.0)
+      platform-api
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -93,7 +115,10 @@ GEM
     minitest (5.9.0)
     momentjs-rails (2.11.1)
       railties (>= 3.1)
+    moneta (0.8.1)
     multi_json (1.12.1)
+    multipart-post (2.0.0)
+    netrc (0.11.0)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
@@ -191,7 +216,9 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   kaminari
+  letsencrypt-rails-heroku
   momentjs-rails (>= 2.9.0)
+  platform-api!
   puma
   rails (= 4.2.5)
   rails_12factor

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
@@ -76,4 +76,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+  
+  # Letsencrypt SSL certificate generation middleware
+  config.middleware.insert_before ActionDispatch::SSL, Letsencrypt::Middleware
 end


### PR DESCRIPTION
In order to secure the Network application the Rails force_ssl
configuration option is not set.  This will redirect http requests
to https requests.

To support the force_ssl option, there must be an certificate.
Letsencrypt is being used to generate certificates on a monthly basis
in an automated way.  The benefits are primarily that certificates
are automatically renewed going forward and secondarily they are free.

See https://github.com/pixielabs/letsencrypt-rails-heroku and
https://letsencrypt.org/ for details.