### PR TITLE
Added event status

### DIFF
--- a/app/controllers/network_events_controller.rb
+++ b/app/controllers/network_events_controller.rb
@@ -147,6 +147,7 @@ class NetworkEventsController < ApplicationController
     def network_event_params
       params.require(:network_event).permit(
         :name, 
+        :status,
         :program_id, 
         :location_id, 
         :scheduled_at, 

--- a/app/helpers/network_events_helper.rb
+++ b/app/helpers/network_events_helper.rb
@@ -50,5 +50,5 @@ module NetworkEventsHelper
                 "Notes: " + event.try(:notes).to_s
     return event_info
   end
-        
+  
 end

--- a/app/models/network_event.rb
+++ b/app/models/network_event.rb
@@ -46,6 +46,17 @@ class NetworkEvent < ActiveRecord::Base
     where(scheduled_at: start_date.beginning_of_day..end_date.end_of_day)
   end
 
+  def self.statuses
+    [
+      "working",
+      "confirmed", 
+      "scheduled", 
+      "completed", 
+      "declined", 
+      "need to contact and pending further convo with supervisor"
+    ]
+  end
+        
   def date
     scheduled_at.to_date
   end

--- a/app/views/network_events/_form.html.erb
+++ b/app/views/network_events/_form.html.erb
@@ -18,6 +18,19 @@
       <%= f.text_field :name, class: "form-control" %>
     </div>
   </div>
+  <% if @network_event.persisted? %>
+    <div class="form-group">
+      <%= f.label :status, class: "col-sm-2 control-label" %>
+      <div class="col-sm-10">
+        <%= f.collection_select :status, 
+              NetworkEvent.statuses, 
+              :to_s, 
+              :titleize, 
+              {}, 
+              class: "select2 form-control" %>
+      </div>
+    </div>
+  <% end %>
   <div class="form-group">
     <%= f.label :program_id, class: "col-sm-2 control-label" %>
     <div class="col-sm-10">

--- a/app/views/network_events/index.csv.erb
+++ b/app/views/network_events/index.csv.erb
@@ -1,9 +1,10 @@
 <% require 'csv' %>
 <%= CSV.generate(headers: true, :quote_char=>'"', :force_quotes => true,) do |csv|
-  csv << %w{name program location organizations date start_time end_time school cohorts classes school_contacts site_contacts notes}
+  csv << %w{name status program location organizations date start_time end_time school cohorts classes school_contacts site_contacts notes}
   @network_events.each do |event|
     csv << [
       event.name,
+      event.status,
       event.program_name,
       event.location_name,
       event.organizations.map(&:name).join(', '),

--- a/app/views/network_events/index.html.erb
+++ b/app/views/network_events/index.html.erb
@@ -138,13 +138,14 @@
   <table class="table table-striped table-bordered table-hover">
     <thead>
       <tr>
-            <th><%= sortable "name"%></th>
-            <th><%= sortable "program"%></th>
-            <th><%= sortable "location"%></th>
-            <th>Organization(s)</th>
-            <th>Volunteer(s)</th>
-            <th><%= sortable "scheduled_at", "Scheduled at"%></th>
-            <th></th>
+        <th><%= sortable "name"%></th>
+        <th><%= sortable "status"%></th>
+        <th><%= sortable "program"%></th>
+        <th><%= sortable "location"%></th>
+        <th>Organization(s)</th>
+        <th>Volunteer(s)</th>
+        <th><%= sortable "scheduled_at", "Scheduled at"%></th>
+        <th></th>
         <th></th>
         <th></th>
         <th></th>
@@ -154,6 +155,7 @@
     <tbody>
       <%= content_tag_for(:tr, @network_events) do |network_event| %>
         <td><%= network_event.name %></td>
+        <td><%= network_event.status.try(:titleize) %></td>
         <td><%= network_event.program.try(:name) %></td>
         <td><%= network_event.location.try(:name) %></td>
         <td><%= network_event.organizations.map(&:name).join(', ') %></td>

--- a/app/views/network_events/index.json.jbuilder
+++ b/app/views/network_events/index.json.jbuilder
@@ -1,4 +1,4 @@
 json.array!(@network_events) do |network_event|
-  json.extract! network_event, :id, :name, :program_id, :location_id, :scheduled_at, :user_id
+  json.extract! network_event, :id, :name, :status, :program_id, :location_id, :scheduled_at, :user_id
   json.url network_event_url(network_event, format: :json)
 end

--- a/app/views/network_events/show.html.erb
+++ b/app/views/network_events/show.html.erb
@@ -14,6 +14,9 @@
   <dt>Name:</dt>
   <dd><%= @network_event.name %></dd>
 
+  <dt>Status:</dt>
+  <dd><%= @network_event.status.try(:titleize) %></dd>
+
   <dt>Program:</dt>
   <dd><%= @network_event.program.try(:name) %></dd>
 

--- a/app/views/network_events/show.json.jbuilder
+++ b/app/views/network_events/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! @network_event, :id, :name, :program_id, :location_id, :scheduled_at, :user_id, :created_at, :updated_at
+json.extract! @network_event, :id, :name, :program_id, :location_id, :scheduled_at, :status, :user_id, :created_at, :updated_at

--- a/db/migrate/20161229194057_add_status_to_event.rb
+++ b/db/migrate/20161229194057_add_status_to_event.rb
@@ -1,0 +1,5 @@
+class AddStatusToEvent < ActiveRecord::Migration
+  def change
+    add_column :network_events, :status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161130205854) do
+ActiveRecord::Schema.define(version: 20161229194057) do
 
   create_table "affiliations", force: :cascade do |t|
     t.integer  "member_id"
@@ -157,6 +157,7 @@ ActiveRecord::Schema.define(version: 20161130205854) do
     t.boolean  "needs_transport"
     t.datetime "transport_ordered_on"
     t.text     "notes"
+    t.string   "status"
   end
 
   add_index "network_events", ["program_id"], name: "index_network_events_on_program_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -143,6 +143,7 @@ Location.all.each do |location|
       graduating_classes: [class_of_2016, class_of_2017],
       cohorts: [gear_up],
       scheduled_at: rand(14).days.from_now,
+      status: NetworkEvent.statuses.sample,
       user_id: user.id
     )
   end

--- a/test/fixtures/network_events.yml
+++ b/test/fixtures/network_events.yml
@@ -6,6 +6,7 @@ tuggle_network:
   location: tuggle
   scheduled_at: 2016-08-01 01:00:00
   notes: notes_1
+  status: confirmed
   user: one
 
 carver_tour:
@@ -14,4 +15,5 @@ carver_tour:
   location: uab
   scheduled_at: 2016-08-01 02:00:00
   notes: notes_2
+  status: completed
   user: two

--- a/test/support/files/network_events.csv
+++ b/test/support/files/network_events.csv
@@ -1,3 +1,3 @@
-"name","program","location","organizations","date","start_time","end_time","school","cohorts","classes","school_contacts","site_contacts","notes"
-"Tuggle Network Night","Network Night","Tuggle Elementary School","EAB","08-01-2016","01:00","02:00","Tuggle Elementary School","green, purple","2017","George Carver, Martin King","Carrie Tuggle, Rosa Parks","notes_1"
-"Carver UAB Tour","College 101","UAB","EAB","08-01-2016","02:00","03:00","Carver High School","blue, red","2020","Jane Doe, John Smith","Ossie Mitchell, Malachi Wilkerson","notes_2"
+"name","status","program","location","organizations","date","start_time","end_time","school","cohorts","classes","school_contacts","site_contacts","notes"
+"Tuggle Network Night","confirmed","Network Night","Tuggle Elementary School","EAB","08-01-2016","01:00","02:00","Tuggle Elementary School","green, purple","2017","George Carver, Martin King","Carrie Tuggle, Rosa Parks","notes_1"
+"Carver UAB Tour","completed","College 101","UAB","EAB","08-01-2016","02:00","03:00","Carver High School","blue, red","2020","Jane Doe, John Smith","Ossie Mitchell, Malachi Wilkerson","notes_2"


### PR DESCRIPTION
In order to be able to discern the current progress on preparation
for an event, the status attribute was added so that event managers
can see at a glance whether an event has been prepared for.