### PR TITLE
Added mongo_id to the network event

### DIFF
--- a/db/migrate/20170108211004_add_mongo_id_to_network_event.rb
+++ b/db/migrate/20170108211004_add_mongo_id_to_network_event.rb
@@ -1,0 +1,5 @@
+class AddMongoIdToNetworkEvent < ActiveRecord::Migration
+  def change
+    add_column :network_events, :mongo_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161229194057) do
+ActiveRecord::Schema.define(version: 20170108211004) do
 
   create_table "affiliations", force: :cascade do |t|
     t.integer  "member_id"
@@ -158,6 +158,7 @@ ActiveRecord::Schema.define(version: 20161229194057) do
     t.datetime "transport_ordered_on"
     t.text     "notes"
     t.string   "status"
+    t.string   "mongo_id"
   end
 
   add_index "network_events", ["program_id"], name: "index_network_events_on_program_id"

--- a/scripts/import_calendar.rb
+++ b/scripts/import_calendar.rb
@@ -392,8 +392,8 @@ CSV.foreach("tmp/calendar.csv", headers: true) do |row|
             program_id: programs[row["Program"]],
             location_id: location_lookup(locations, row["Location"]),
             scheduled_at: scheduled_at,
-            duration: scheduled_duration
-            # , mongo_id: "csv.calendar.#{index}"
+            duration: scheduled_duration,
+            mongo_id: "csv.calendar.#{index}"
         )
         # row["School"].try(:split, ', ').try(:each) do |school|
         #     values.add school


### PR DESCRIPTION
Since some network events will be loaded from the previous mongodb
database, a column to put the mongodb database id in the postgresql
database will allow for correcting data that is mistakenly loaded.
Also, the row of the csv file for new events loaded from the spreadsheet
was added to the csv import script.