### PR TITLE
Changed attendee match to require all cohorts

### DIFF
--- a/app/models/network_event.rb
+++ b/app/models/network_event.rb
@@ -65,7 +65,11 @@ class NetworkEvent < ActiveRecord::Base
     member_scope = Member.uniq
 
     if cohorts.any?
-      member_scope = member_scope.joins(:cohorts).where(cohorts: { id: cohort_ids })
+      member_scope = member_scope.
+        joins(:cohorts).
+        where(cohorts: { id: cohort_ids }).
+        having("COUNT(cohorts.id) = #{cohort_ids.count}").
+        group("members.id")
     end
 
     if schools.any?


### PR DESCRIPTION
If an event has more than one cohort then a student must have
all the cohorts associated with the event to be an invited attendee.

See issue #418.