### PR TITLE
Changed Organizations label on network event form

### DIFF
--- a/app/views/network_events/_form.html.erb
+++ b/app/views/network_events/_form.html.erb
@@ -54,7 +54,7 @@
     </div>
   </div>
   <div class="form-group">
-    <%= f.label :organization_ids, class: "col-sm-2 control-label" %>
+    <%= f.label :organization_ids, 'Organizations', class: "col-sm-2 control-label" %>
     <div class="col-sm-10">
       <%= f.collection_select :organization_ids, 
             Organization.order(:name).all, 


### PR DESCRIPTION
The form helper was creating a label for the organizations
that didn't make sense so added customized label to form