### PR TITLE
Network event invitees require cohort, school, or class

### DIFF
--- a/app/models/network_event.rb
+++ b/app/models/network_event.rb
@@ -62,22 +62,26 @@ class NetworkEvent < ActiveRecord::Base
   end
   
   def invitees
-    member_scope = Member.uniq
-
-    if cohorts.any?
-      member_scope = member_scope.
-        joins(:cohorts).
-        where(cohorts: { id: cohort_ids }).
-        having("COUNT(cohorts.id) = #{cohort_ids.count}").
-        group("members.id")
-    end
-
-    if schools.any?
-      member_scope = member_scope.where(school_id: school_ids)
-    end
-
-    if graduating_classes.any?
-      member_scope = member_scope.where(graduating_class_id: graduating_class_ids)
+    if cohorts.any? || schools.any? || graduating_classes.any?
+      member_scope = Member.uniq
+  
+      if cohorts.any?
+        member_scope = member_scope.
+          joins(:cohorts).
+          where(cohorts: { id: cohort_ids }).
+          having("COUNT(cohorts.id) = #{cohort_ids.count}").
+          group("members.id")
+      end
+  
+      if schools.any?
+        member_scope = member_scope.where(school_id: school_ids)
+      end
+  
+      if graduating_classes.any?
+        member_scope = member_scope.where(graduating_class_id: graduating_class_ids)
+      end
+    else
+      member_scope = Member.none
     end
 
     member_scope

--- a/test/fixtures/members.yml
+++ b/test/fixtures/members.yml
@@ -18,7 +18,7 @@ one:
   extra_groups: MyString
   other_networks: MyString
   user: one
-  graduating_class: one
+  graduating_class: class_of_2016
 
 two:
   first_name: MyString
@@ -38,7 +38,7 @@ two:
   extra_groups: MyString
   other_networks: MyString
   user: two
-  graduating_class: one
+  graduating_class: class_of_2017
 
 jane:
   first_name: Jane

--- a/test/models/network_event_test.rb
+++ b/test/models/network_event_test.rb
@@ -1,7 +1,31 @@
 require 'test_helper'
 
 class NetworkEventTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  
+  def network_event_attributes(additional_attributes={})
+    {
+      name: 'Test',
+      program: programs(:network_night),
+      scheduled_at: 1.day.from_now,
+      location: locations(:tuggle)
+    }.merge(additional_attributes)
+  end 
+  
+  test "NetworkEvent invitees requires cohort, school or graduating class" do
+    network_event = NetworkEvent.create!(network_event_attributes)
+    
+    assert_empty network_event.invitees
+  end 
+  
+  test "Network invitees should be constrained by graduation class" do
+    network_event = NetworkEvent.create!(
+      network_event_attributes(
+        graduating_class_ids: [graduating_classes(:class_of_2016).id]
+      )
+    )
+    
+    assert_includes network_event.invitees, members(:one)
+    refute_includes network_event.invitees, members(:two)
+  end
+  
 end


### PR DESCRIPTION
If a network event does not have a cohort, school or graduating
class associated with it then it should not return any invitees
for the checkin screen.  It was returning all the members in the
system in this scenario.  To correct this problem, the invitees
returns a "none" query.