### PR TITLE
Fix transport date to save without date

### DIFF
--- a/app/assets/javascripts/network_events.coffee
+++ b/app/assets/javascripts/network_events.coffee
@@ -1,11 +1,19 @@
 $(document).on 'ready page:load', ->
   client = new ZeroClipboard($('.copy_button'))
   $('.copy_button').tooltip()
+  
+  $('#transport-datetimepicker').datetimepicker({
+      showClear: true,
+      format: 'YYYY-MM-DD hh:mm a',
+      useCurrent: false
+    })
+    
   checked = $('#network_event_needs_transport').is(':checked')
   if checked
     $('#order_div').show()
   else
     $('#order_div').hide()
+    
   $('#network_event_needs_transport').change ->
     $('#order_div').slideToggle()
-      
+    $('#network_event_transport_ordered_on').val("")

--- a/app/views/network_events/_form.html.erb
+++ b/app/views/network_events/_form.html.erb
@@ -165,7 +165,12 @@
   <div class="form-group" id='order_div'>
     <%= f.label :transport_ordered_on, 'Transportation Ordered', class: "col-sm-2 control-label" %>
     <div class="col-sm-10">
-      <%= f.datetime_select :transport_ordered_on, class: "form-control" %>
+      <div class="input-group date" id="transport-datetimepicker">
+         <input type='text' class="form-control" name="network_event[transport_ordered_on]" id="network_event_transport_ordered_on" value="<%= @network_event.transport_ordered_on %>" />
+                    <span class="input-group-addon">
+                        <span class="glyphicon glyphicon-calendar"></span>
+                    </span>
+      </div>
       </div>
     </div>
   <div class="form-group">


### PR DESCRIPTION
Replaced default picker with bootstrap version. Ensured date value clears
when user unchecks appropriate checkbox. Connects to #410.