### PR TITLE
initial error pages for network

### DIFF
--- a/app/assets/javascripts/errors.coffee
+++ b/app/assets/javascripts/errors.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  # include HttpResponseConcern
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
@@ -6,11 +7,22 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   before_action :require_admin_user!
   
+  # rescue_from ActiveRecord::RecordNotFound, :with => :page_not_found
+  # rescue_from StandardError, :with => :internal_server_error
+  
   protected
   
   def require_admin_user!
     unless current_user.admin?
-      redirect_to root_path
+      request.referrer || root_path
     end
   end
+  
+  # def page_not_found
+  #   render_404
+  # end
+  
+  # def internal_server_error
+  #   render_500
+  # end
 end

--- a/app/controllers/concerns/http_response_concern.rb
+++ b/app/controllers/concerns/http_response_concern.rb
@@ -1,0 +1,10 @@
+module HttpResponseConcern
+  extend ActiveSupport::Concern
+  def render_404
+    render file: 'public/404.html', status: 404, layout: false
+  end
+  
+  def render_500
+    render file: 'public/500.html', status: 500, layout: false
+  end
+end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,10 @@
+class ErrorsController < ApplicationController
+  
+  def not_found
+    render file: 'public/404.html', status: 404, layout: true
+  end
+  def internal_server_error
+    render file: 'public/500.html', status: 500, layout: true
+  end
+end
+

--- a/app/helpers/errors_helper.rb
+++ b/app/helpers/errors_helper.rb
@@ -1,0 +1,2 @@
+module ErrorsHelper
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,7 @@ module Workspace
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+    
+    config.exceptions_app = self.routes
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -10,7 +10,8 @@ Rails.application.configure do
   config.eager_load = false
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = false
+
   config.action_controller.perform_caching = false
 
   # Don't care if the mailer can't send.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+
   resources :common_tasks
   resources :neighborhoods
   resources :extracurricular_activities
@@ -35,6 +36,9 @@ Rails.application.routes.draw do
   resources :members do
     resources :communications, only: [:new, :show, :create, :edit, :update, :destroy]
   end
+  
+  match "/404", :to => "errors#not_found", :via => :all
+  match "/500", :to => "errors#internal_server_error", :via => :all
   
   resources :locations
   resources :organizations

--- a/public/404.html
+++ b/public/404.html
@@ -4,52 +4,14 @@
   <title>The page you were looking for doesn't exist (404)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
-  body {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
-
-  div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
-
-  div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-
   h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
+	  margin: 0 auto;
+	  position: initial;
   }
 
-  div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  p {
+	  font-size: 20px;
+	  margin: 30px;
   }
   </style>
 </head>
@@ -58,10 +20,11 @@
   <!-- This file lives in public/404.html -->
   <div class="dialog">
     <div>
-      <h1>The page you were looking for doesn't exist.</h1>
-      <p>You may have mistyped the address or the page may have moved.</p>
+      <img src="http://www.clker.com/cliparts/y/O/8/Z/l/C/blue-graduation-cap.svg"></img>
+      <h1>It looks like nothing was found at this location</h1>
+      <p>The page you have requested does not exist or the page may have moved.</p>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
+    <p><a href="javascript:history.back()">Go Back</a></p>
   </div>
 </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -4,52 +4,14 @@
   <title>We're sorry, but something went wrong (500)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
-  body {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
-
-  div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
-
-  div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-
   h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
+	  margin: 0 auto;
+	  position: initial;
   }
 
-  div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  p {
+	  font-size: 20px;
+	  margin: 30px;
   }
   </style>
 </head>
@@ -58,9 +20,10 @@
   <!-- This file lives in public/500.html -->
   <div class="dialog">
     <div>
-      <h1>We're sorry, but something went wrong.</h1>
+      <img src="http://media.inktastic.com/thumbnail/500/968/41/41968500.1.png"></img>
+      <h1>The request was unsuccessful due to an unexpected condition encountered by the server.</h1>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
+    <p><a href='/'>Take me back</a></p>
   </div>
 </body>
 </html>

--- a/test/controllers/errors_controller_test.rb
+++ b/test/controllers/errors_controller_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class ErrorsControllerTest < ActionController::TestCase
+  test "should get not_found" do
+    get :not_found
+    assert_response :success
+  end
+
+  test "should get internal_server_error" do
+    get :internal_server_error
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
so I mixed this [approach](https://mattbrictson.com/dynamic-rails-error-pages) with [this](http://stackoverflow.com/questions/19103759/rails-4-custom-error-pages-for-404-500-and-where-is-the-default-500-error-mess/25303705) because I don't know if it is necessary to create views for error pages if that is the case and you would like me to approach it that way then I can further work on these errors but for the meantime both errors that I created gave me the logs 
```
Processing by ErrorsController#not_found as HTML
  Parameters: {"id"=>"123"}
  Rendered public/404.html within layouts/application (1.1ms)
Completed 404 Not Found in 316ms (Views: 316.0ms | ActiveRecord: 0.0ms)
```
and

```
Processing by ErrorsController#internal_server_error as HTML
  Rendered public/500.html within layouts/application (0.1ms)
Completed 500 Internal Server Error in 143ms (Views: 142.1ms | ActiveRecord: 0.0ms)
```

here are the snapshots as well with really basic css, which I modified from the existing public folder
<img width="555" alt="screen shot 2017-03-04 at 3 38 17 pm" src="https://cloud.githubusercontent.com/assets/9599485/23582182/8d263a7c-00f2-11e7-938f-9a0b70f6518f.png">

and

<img width="555" alt="screen shot 2017-03-04 at 3 39 44 pm" src="https://cloud.githubusercontent.com/assets/9599485/23582184/9b4e905e-00f2-11e7-8de5-9114d6917407.png">

Please let me know if you have any questions or concerns.

