### PR TITLE
Add task list to event show page

### DIFF
--- a/app/assets/javascripts/check_ins.coffee
+++ b/app/assets/javascripts/check_ins.coffee
@@ -4,7 +4,7 @@
 $(document).on 'ready page:load', ->
   event_id = $('#network_event_id').val()
   member_level = $('#level').val()
-  $('table :button').click ->
+  $('.check_in').click ->
     table_row = $(this).closest("tr")
     row_member_id = $(this).siblings(".row_member_id").val()
     $.ajax({

--- a/app/assets/javascripts/network_event_tasks.coffee
+++ b/app/assets/javascripts/network_event_tasks.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/network_events.coffee
+++ b/app/assets/javascripts/network_events.coffee
@@ -30,4 +30,11 @@ $(document).on 'ready page:load', ->
     else
       $(this).parent().parent().find(':input').filter('.task-field').prop("disabled", true)
       
+  $('.task_button').on "ajax:success", (e, data, status, xhr) ->
+    $(this).removeClass("btn-primary").addClass("btn-success")
+    console.log("SUCCESS")
+    console.log(data.inspect)
+    
+    
+    
         

--- a/app/controllers/network_event_tasks_controller.rb
+++ b/app/controllers/network_event_tasks_controller.rb
@@ -1,0 +1,20 @@
+class NetworkEventTasksController < ApplicationController
+  
+  def update
+    @network_event_task = NetworkEventTask.find(params[:id])
+    respond_to do |format|
+      if @network_event_task.update(network_event_task_params)
+        format.js {}
+      else
+        console.log("failure")
+      end
+    end 
+  end
+  
+  private
+  
+  def network_event_task_params
+    params.require(:network_event_task).permit(:id, :name, :network_event_id, :common_task_id, :completed_at) 
+  end
+  
+end

--- a/app/controllers/network_events_controller.rb
+++ b/app/controllers/network_events_controller.rb
@@ -13,6 +13,12 @@ class NetworkEventsController < ApplicationController
   # GET /network_events/1
   # GET /network_events/1.json
   def show
+    @completed_tasks_count = 0 
+    @network_event.network_event_tasks.each do |task|
+      if task.completed_at != nil
+        @completed_tasks_count += 1
+      end
+    end
   end
 
   # GET /network_events/new

--- a/app/helpers/network_event_tasks_helper.rb
+++ b/app/helpers/network_event_tasks_helper.rb
@@ -1,0 +1,2 @@
+module NetworkEventTasksHelper
+end

--- a/app/views/network_event_tasks/update.html.erb
+++ b/app/views/network_event_tasks/update.html.erb
@@ -1,0 +1,4 @@
+<div class="page-header">
+  <h1>NetworkEventTasks#update</h1>
+</div>
+<p>Find me in app/views/network_event_tasks/update.html.erb</p>

--- a/app/views/network_event_tasks/update.js.erb
+++ b/app/views/network_event_tasks/update.js.erb
@@ -1,0 +1,18 @@
+
+var task_id = "<%= @network_event_task.id%>";
+var row_id_selecter = "#network_event_task_" + task_id;
+
+// Pass new completed_at attribute
+var task_completed_at = "<%= @network_event_task.completed_at.to_formatted_s(:long) %>";
+
+// Update table row
+var row = $("tr" + row_id_selecter);
+row.find("td.task_completed_at").text(task_completed_at);
+row.find("td.task_mark").find(".task_button").replaceWith("Completed");
+
+// Update ratio heading
+var ratio = $("#ratio").text();
+var num = ratio.slice(0, ratio.indexOf("/")).trim();
+var rest = ratio.slice(ratio.indexOf("/")).trim();
+var amount = parseInt(num) + 1;
+$("#ratio").text(amount + " " + rest);

--- a/app/views/network_events/show.html.erb
+++ b/app/views/network_events/show.html.erb
@@ -101,15 +101,6 @@
   <dt>Transportation ordered:</dt>
   <dd><%= @network_event.transport_ordered_on %></dd>
   
-  <dt>Task list:</dt>
-  <% if @network_event.network_event_tasks.present? %>
-    <%= content_tag_for(:dd, @network_event.network_event_tasks) do |task| %>
-      <%= task.name %>
-    <% end %>
-  <% else %>
-    <dd></dd>
-  <% end %>
-  
   <dt>Notes:</dt>
   <dd><%= @network_event.notes %></dd>
   
@@ -126,6 +117,38 @@
     </div>
   </dd>
 </dl>
+
+<h2>Event Task List</h2>
+  <h3 id="ratio"><%= @completed_tasks_count %> / <%= @network_event.network_event_tasks.length %> Completed</h3>
+  <div class="table-responsive">
+    <table class="table table-striped table-bordered table-hover">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Completed at</th>
+          <th></th>
+        </tr>
+      </thead>
+  
+      <tbody>
+        <%= content_tag_for(:tr, @network_event.network_event_tasks) do |task| %>
+          <td class="task_name"><%= task.name %></td>
+          <td class="task_completed_at"><%= if task.completed_at.present? then task.completed_at.to_formatted_s(:long) end %></td>
+          <td class="task_mark">
+            <% if not task.completed_at.present? %>
+              <%= button_to("Mark Completed", network_event_task_path(task) , remote: true, method: :patch, name: "task_button", class:"btn btn-primary task_button",
+                            params: { :"network_event_task[name]" => task.name,
+                                      :"network_event_task[network_event_id]" => task.network_event_id,
+                                      :"network_event_task[common_task_id]" => task.common_task_id,
+                                      :"network_event_task[completed_at]" => Time.now }) %>
+            <% else %>
+              Completed 
+            <% end %>
+          </td>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
 
 <h2>Invitees</h2>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get 'network_event_tasks/update'
+
   resources :common_tasks
   resources :neighborhoods
   resources :extracurricular_activities
@@ -8,6 +10,7 @@ Rails.application.routes.draw do
   resources :graduating_classes
   resources :network_actions
   resources :programs
+  resources :network_event_tasks, only: [:update]
   
   resources :network_events do
     resources :sign_ups, only: [:new, :show, :create, :edit, :update]

--- a/test/controllers/network_event_tasks_controller_test.rb
+++ b/test/controllers/network_event_tasks_controller_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class NetworkEventTasksControllerTest < ActionController::TestCase
+  include Devise::TestHelpers
+  
+  setup do
+    @network_event_task = network_event_tasks(:one)
+    sign_in users(:one)
+  end
+  
+  test "should update with ajax" do
+    xhr :patch, :update, id: @network_event_task, 
+          network_event_task: {name: @network_event_task.name, 
+          network_event_id: @network_event_task.network_event_id,
+          common_task_id: @network_event_task.common_task_id,
+          completed_at: @network_event_task.completed_at }
+    assert_response :success
+  end
+
+end

--- a/test/fixtures/network_event_tasks.yml
+++ b/test/fixtures/network_event_tasks.yml
@@ -4,16 +4,19 @@ one:
   name: MyString
   network_event: tuggle_network 
   common_task: one
+  completed_at: 2016-08-01 01:00:00
   user: one
 
 two:
   name: MyString
   network_event: carver_tour 
   common_task: two
+  completed_at: 2016-08-01 01:00:00
   user: one
   
 three:
   name: MyString
   network_event: dateless_event 
   common_task: two
+  completed_at: 2016-08-01 01:00:00
   user: one


### PR DESCRIPTION
Added the task list to the event show page. Users can mark off tasks as they're completed and the date/time is recorded.
Connects to #455.