### PR TITLE
Fixed a data issue with the identity migration script

### DIFF
--- a/app/views/members/index.csv.erb
+++ b/app/views/members/index.csv.erb
@@ -8,7 +8,7 @@
       row.last_name,
       row.phone,
       row.email,
-      row.identity.name,
+      row.identity.try(:name),
       row.affiliation_list,
       row.graduation_year,
       row.address,

--- a/scripts/migrate_identities.rb
+++ b/scripts/migrate_identities.rb
@@ -13,5 +13,5 @@ pg.exec("UPDATE members SET identity_id=1 WHERE members.identity ='Student'")
 pg.exec("UPDATE members SET identity_id=2 WHERE members.identity ='Parent'")
 pg.exec("UPDATE members SET identity_id=3 WHERE members.identity ='Educator'")
 pg.exec("UPDATE members SET identity_id=4 WHERE members.identity ='Resident'")
-pg.exec("UPDATE members SET identity_id=5 WHERE members.identity ='Community\ Partner'")
+pg.exec("UPDATE members SET identity_id=5 WHERE members.identity ='Community Partner'")
 


### PR DESCRIPTION
The migration script did not match the data in the production database for
Community Partner.  Also, a reference to the identity name was not save if
and identity was not assigned to the member.