### PR TITLE
Add owner field to common/network task field

### DIFF
--- a/app/controllers/common_tasks_controller.rb
+++ b/app/controllers/common_tasks_controller.rb
@@ -69,6 +69,6 @@ class CommonTasksController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def common_task_params
-      params.require(:common_task).permit(:name, :user_id)
+      params.require(:common_task).permit(:name, :owner_id, :user_id)
     end
 end

--- a/app/controllers/network_event_tasks_controller.rb
+++ b/app/controllers/network_event_tasks_controller.rb
@@ -14,7 +14,7 @@ class NetworkEventTasksController < ApplicationController
   private
   
   def network_event_task_params
-    params.require(:network_event_task).permit(:id, :name, :network_event_id, :common_task_id, :completed_at) 
+    params.require(:network_event_task).permit(:id, :name, :network_event_id, :common_task_id, :completed_at, :owner_id) 
   end
   
 end

--- a/app/controllers/network_events_controller.rb
+++ b/app/controllers/network_events_controller.rb
@@ -21,7 +21,7 @@ class NetworkEventsController < ApplicationController
     @network_event = NetworkEvent.new
     @common_tasks = CommonTask.all
     @common_tasks.each do |common_task|
-      @network_event.network_event_tasks.build(common_task_id: common_task.id, name: common_task.name)
+      @network_event.network_event_tasks.build(common_task_id: common_task.id, name: common_task.name, owner_id: common_task.owner_id)
     end
   end
 
@@ -174,7 +174,7 @@ class NetworkEventsController < ApplicationController
         :graduating_class_ids => [],
         :school_ids => [],
         :cohort_ids => [],
-        :network_event_tasks_attributes => [:id, :name, :scheduled_at, :common_task_id, :network_event_id]
+        :network_event_tasks_attributes => [:id, :name, :scheduled_at, :common_task_id, :network_event_id, :owner_id ]
       )
     end
 end

--- a/app/models/common_task.rb
+++ b/app/models/common_task.rb
@@ -1,3 +1,4 @@
 class CommonTask < ActiveRecord::Base
   belongs_to :user
+  belongs_to :owner, :class_name => "User"
 end

--- a/app/models/network_event_task.rb
+++ b/app/models/network_event_task.rb
@@ -2,6 +2,7 @@ class NetworkEventTask < ActiveRecord::Base
   belongs_to :user
   belongs_to :network_event
   belongs_to :common_task
+  belongs_to :owner, :class_name => "User"
   
   validates_presence_of :name
   validates_presence_of :common_task_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,6 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable
 
   has_many :created_organizations, class_name: "Organization", foreign_key: :created_by_id
+  has_many :common_tasks
+  has_many :network_event_tasks
 end

--- a/app/views/common_tasks/_form.html.erb
+++ b/app/views/common_tasks/_form.html.erb
@@ -19,6 +19,17 @@
     </div>
   </div>
   <div class="form-group">
+    <%= f.label :owner, class: "col-sm-2 control-label" %>
+    <div class="col-sm-10">
+      <%= f.collection_select :owner_id, 
+            User.order(:email).all,
+            :id,
+            :email,
+            {},
+            class: "select2 form-control" %>
+    </div>
+  </div>
+  <div class="form-group">
     <div class="col-sm-offset-2 col-sm-10">
       <%= f.submit class: "btn btn-primary" %>
     </div>

--- a/app/views/common_tasks/index.html.erb
+++ b/app/views/common_tasks/index.html.erb
@@ -11,7 +11,7 @@
     <thead>
       <tr>
             <th>Name</th>
-            <th>User</th>
+            <th>Owner</th>
             <th></th>
         <th></th>
         <th></th>
@@ -21,7 +21,7 @@
     <tbody>
       <%= content_tag_for(:tr, @common_tasks) do |common_task| %>
             <td><%= common_task.name %></td>
-            <td><%= common_task.user.try(:email) %></td>
+            <td><%= common_task.owner.try(:email) %></td>
             <td><%= link_to 'Show', common_task %></td>
         <td><%= link_to 'Edit', edit_common_task_path(common_task) %></td>
         <td><%= link_to 'Destroy', common_task, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/common_tasks/show.html.erb
+++ b/app/views/common_tasks/show.html.erb
@@ -7,13 +7,16 @@
     <span class="glyphicon glyphicon-pencil"></span>
     Edit
   <% end %>
-  <h1>Show common_task</h1>
+  <h1>Show common tasks</h1>
 </div>
 
 <dl class="dl-horizontal">
   <dt>Name:</dt>
   <dd><%= @common_task.name %></dd>
 
+  <dt>Owner:</dt>
+  <dd><%= @common_task.owner.try(:email) %></dd>
+  
   <dt>Creator:</dt>
   <dd><%= @common_task.user.try(:email) %></dd>
 

--- a/app/views/network_events/_form.html.erb
+++ b/app/views/network_events/_form.html.erb
@@ -178,30 +178,37 @@
       </div>
       </div>
     </div>
-  <% if @network_event.new_record?%>
-    <div class="form-group">
-      <%= f.label :network_event_tasks, "Task List", class: "col-sm-2 control-label" %>
-      <div class="col-md-10">
-        <%= f.fields_for :network_event_tasks do |event_task| %>
-          <div class="form-group row">
-            <div class="col-md-11">
-            <%= event_task.text_field :name, :disabled => true, class: "form-control task-field" %>
-            <%= event_task.hidden_field :common_task_id , :disabled => true, class: "task-field" %>
-          </div>
-          <div class="col-md-1">
-            <%= check_box_tag "task_present", "0", false, class: "form-control task-chk" %>
-          </div>
-          </div>
-        <% end %>
-        </div>
-    </div>
-  <% end %>
   <div class="form-group">
     <%= f.label :notes, class: "col-sm-2 control-label" %>
     <div class="col-sm-10">
       <%= f.text_area :notes, class: "form-control" %>
     </div>
   </div>
+  <% if @network_event.new_record?%>
+    <div class="form-group">
+      <%= f.label :network_event_tasks, "Task List", class: "col-sm-2 control-label" %>
+      <div class="col-md-10">
+          <div class="form-group row">
+            <%= label_tag "Task",nil, class:"col-sm-6" %>
+            <%= label_tag "Owner",nil, class:"col-sm-5" %>
+          </div>
+        <%= f.fields_for :network_event_tasks do |event_task| %>
+          <div class="form-group row">
+            <div class="col-md-6">
+              <%= event_task.text_field :name, disabled: true, class: "form-control task-field" %>
+              <%= event_task.hidden_field :common_task_id , disabled: true, class: "task-field" %>
+            </div>
+            <div class="col-md-5">
+              <%= event_task.collection_select :owner_id, User.all, :id, :email, {}, class: "select2 form-control task-field", disabled: true %>
+            </div>
+            <div class="col-md-1">
+              <%= check_box_tag "task_present", "0", false, class: "form-control task-chk" %>
+            </div>
+          </div>
+        <% end %>
+        </div>
+    </div>
+  <% end %>
   <div class="form-group">
     <div class="col-sm-offset-2 col-sm-10">
       <%= f.submit event_button_name(f.object), class: "btn btn-primary" %>

--- a/app/views/network_events/show.html.erb
+++ b/app/views/network_events/show.html.erb
@@ -126,6 +126,7 @@
         <tr>
           <th>Name</th>
           <th>Completed at</th>
+          <th>Owner</th>
           <th></th>
         </tr>
       </thead>
@@ -134,12 +135,14 @@
         <%= content_tag_for(:tr, @network_event.network_event_tasks) do |task| %>
           <td class="task_name"><%= task.name %></td>
           <td class="task_completed_at"><%= if task.completed_at.present? then task.completed_at.in_time_zone("Central Time (US & Canada)").to_formatted_s(:long) end %></td>
+          <td class="task_owner"><%= task.owner.try(:email) %></td>
           <td class="task_mark">
             <% if not task.completed_at.present? %>
               <%= button_to("Mark Completed", network_event_task_path(task) , remote: true, method: :patch, name: "task_button", class:"btn btn-primary task_button",
                             params: { :"network_event_task[name]" => task.name,
                                       :"network_event_task[network_event_id]" => task.network_event_id,
                                       :"network_event_task[common_task_id]" => task.common_task_id,
+                                      :"network_event_task[owner_id]" => task.owner_id,
                                       :"network_event_task[completed_at]" => Time.now }) %>
             <% else %>
               Completed 

--- a/db/migrate/20170322171523_add_owner_to_common_tasks.rb
+++ b/db/migrate/20170322171523_add_owner_to_common_tasks.rb
@@ -1,0 +1,5 @@
+class AddOwnerToCommonTasks < ActiveRecord::Migration
+  def change
+    add_reference :common_tasks, :owner, index: true, foreign_key: true
+  end
+end

--- a/db/migrate/20170322223833_add_owner_to_network_event_tasks.rb
+++ b/db/migrate/20170322223833_add_owner_to_network_event_tasks.rb
@@ -1,0 +1,5 @@
+class AddOwnerToNetworkEventTasks < ActiveRecord::Migration
+  def change
+    add_reference :network_event_tasks, :owner, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170322163313) do
+ActiveRecord::Schema.define(version: 20170322223833) do
 
   create_table "affiliations", force: :cascade do |t|
     t.integer  "member_id"
@@ -48,7 +48,10 @@ ActiveRecord::Schema.define(version: 20170322163313) do
     t.integer  "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer  "owner_id"
   end
+
+  add_index "common_tasks", ["owner_id"], name: "index_common_tasks_on_owner_id"
 
   create_table "communications", force: :cascade do |t|
     t.string   "kind"
@@ -169,10 +172,12 @@ ActiveRecord::Schema.define(version: 20170322163313) do
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "owner_id"
   end
 
   add_index "network_event_tasks", ["common_task_id"], name: "index_network_event_tasks_on_common_task_id"
   add_index "network_event_tasks", ["network_event_id"], name: "index_network_event_tasks_on_network_event_id"
+  add_index "network_event_tasks", ["owner_id"], name: "index_network_event_tasks_on_owner_id"
 
   create_table "network_events", force: :cascade do |t|
     t.string   "name"


### PR DESCRIPTION
Add owner attribute to common and network tasks. User can specify the default owner of common task
and can specify a different owner for network tasks. Connects to #466.