### PR TITLE
Add due_date to tasks

### DIFF
--- a/app/controllers/common_tasks_controller.rb
+++ b/app/controllers/common_tasks_controller.rb
@@ -69,6 +69,6 @@ class CommonTasksController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def common_task_params
-      params.require(:common_task).permit(:name, :owner_id, :user_id)
+      params.require(:common_task).permit(:name, :owner_id, :user_id, :date_modifier)
     end
 end

--- a/app/controllers/network_event_tasks_controller.rb
+++ b/app/controllers/network_event_tasks_controller.rb
@@ -14,7 +14,7 @@ class NetworkEventTasksController < ApplicationController
   private
   
   def network_event_task_params
-    params.require(:network_event_task).permit(:id, :name, :network_event_id, :common_task_id, :completed_at, :owner_id) 
+    params.require(:network_event_task).permit(:id, :name, :network_event_id, :common_task_id, :completed_at, :owner_id, :due_date, :date_modifier) 
   end
   
 end

--- a/app/controllers/network_events_controller.rb
+++ b/app/controllers/network_events_controller.rb
@@ -21,7 +21,7 @@ class NetworkEventsController < ApplicationController
     @network_event = NetworkEvent.new
     @common_tasks = CommonTask.all
     @common_tasks.each do |common_task|
-      @network_event.network_event_tasks.build(common_task_id: common_task.id, name: common_task.name, owner_id: common_task.owner_id)
+      @network_event.network_event_tasks.build(common_task_id: common_task.id, name: common_task.name, owner_id: common_task.owner_id, date_modifier: common_task.date_modifier)
     end
   end
 
@@ -174,7 +174,7 @@ class NetworkEventsController < ApplicationController
         :graduating_class_ids => [],
         :school_ids => [],
         :cohort_ids => [],
-        :network_event_tasks_attributes => [:id, :name, :scheduled_at, :common_task_id, :network_event_id, :owner_id ]
+        :network_event_tasks_attributes => [:id, :name, :scheduled_at, :common_task_id, :network_event_id, :owner_id, :due_date, :date_modifier]
       )
     end
 end

--- a/app/models/common_task.rb
+++ b/app/models/common_task.rb
@@ -1,4 +1,20 @@
 class CommonTask < ApplicationRecord
   belongs_to :user
   belongs_to :owner, :class_name => "User"
+  
+  def self.date_modifiers 
+    [
+       "Monday before event",
+       "2 Mondays before event",
+       "Friday before event",
+       "2 Fridays before event",
+       "1 week before event",
+       "2 weeks before event",
+       "3 weeks before event",
+       "1 month before event",
+       "2 months before event",
+       "3 months before event",
+       "4 months before event"
+    ]
+  end
 end

--- a/app/models/network_event_task.rb
+++ b/app/models/network_event_task.rb
@@ -1,8 +1,8 @@
 class NetworkEventTask < ApplicationRecord
   belongs_to :user
+  belongs_to :owner, :class_name => "User"
   belongs_to :network_event
   belongs_to :common_task
-  belongs_to :owner, :class_name => "User"
   
   validates_presence_of :name
   validates_presence_of :common_task_id

--- a/app/views/common_tasks/_form.html.erb
+++ b/app/views/common_tasks/_form.html.erb
@@ -27,6 +27,19 @@
             :email,
             {},
             class: "select2 form-control" %>
+      </div>
+  </div>
+  <div class="form-group">
+    <%= f.label :date_modifier, class: "col-sm-2 control-label" %>
+    <div class="col-sm-10">
+      <%= f.collection_select :date_modifier,
+            CommonTask.date_modifiers,
+            :to_s,
+            :titleize,
+            {},
+            class: "select2 form-control",
+            multiple: false,
+            data: {placeholder: 'Select Date Modifier'} %>
     </div>
   </div>
   <div class="form-group">

--- a/app/views/common_tasks/index.html.erb
+++ b/app/views/common_tasks/index.html.erb
@@ -12,6 +12,8 @@
       <tr>
             <th>Name</th>
             <th>Owner</th>
+            <th>Default due date</th>
+            <th>User</th>
             <th></th>
         <th></th>
         <th></th>
@@ -22,6 +24,8 @@
       <%= content_tag_for(:tr, @common_tasks) do |common_task| %>
             <td><%= common_task.name %></td>
             <td><%= common_task.owner.try(:email) %></td>
+            <td><%= common_task.try(:date_modifier) %></td>
+            <td><%= common_task.user.try(:email) %></td>
             <td><%= link_to 'Show', common_task %></td>
         <td><%= link_to 'Edit', edit_common_task_path(common_task) %></td>
         <td><%= link_to 'Destroy', common_task, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/common_tasks/show.html.erb
+++ b/app/views/common_tasks/show.html.erb
@@ -17,6 +17,9 @@
   <dt>Owner:</dt>
   <dd><%= @common_task.owner.try(:email) %></dd>
   
+  <dt>Date Modifier:</dt>
+  <dd><%= @common_task.date_modifier %></dd>
+  
   <dt>Creator:</dt>
   <dd><%= @common_task.user.try(:email) %></dd>
 

--- a/app/views/network_events/_form.html.erb
+++ b/app/views/network_events/_form.html.erb
@@ -187,26 +187,44 @@
   <% if @network_event.new_record?%>
     <div class="form-group">
       <%= f.label :network_event_tasks, "Task List", class: "col-sm-2 control-label" %>
-      <div class="col-md-10">
-          <div class="form-group row">
-            <%= label_tag "Task",nil, class:"col-sm-6" %>
-            <%= label_tag "Owner",nil, class:"col-sm-5" %>
+      <div class="col-sm-10">
+        <div class="row">
+          <div class="col-sm-4">
+            <h5>Tasks</h5>
           </div>
+          <div class="col-sm-4">
+            <h5>Due Date</h5>
+          </div>
+          <div class="col-sm-3">
+            <h5>Owner</h5>
+          </div>
+        </div>
         <%= f.fields_for :network_event_tasks do |event_task| %>
-          <div class="form-group row">
-            <div class="col-md-6">
+          <div class="row">
+            <div class="col-sm-4">
               <%= event_task.text_field :name, disabled: true, class: "form-control task-field" %>
-              <%= event_task.hidden_field :common_task_id , disabled: true, class: "task-field" %>
             </div>
-            <div class="col-md-5">
+            <div class="col-sm-4">
+                <%= event_task.collection_select :date_modifier,
+                      CommonTask.date_modifiers,
+                      :to_s,
+                      :titleize,
+                      {},
+                      class: "select2 form-control task-field",
+                      multiple: false,
+                      disabled: true,
+                      data: {placeholder: 'Select Date Modifier'} %>
+            </div>
+            <div class="col-md-3">
               <%= event_task.collection_select :owner_id, User.all, :id, :email, {}, class: "select2 form-control task-field", disabled: true %>
             </div>
-            <div class="col-md-1">
+              <%= event_task.hidden_field :common_task_id , disabled: true, class: "task-field" %>
+            <div class="col-sm-1">
               <%= check_box_tag "task_present", "0", false, class: "form-control task-chk" %>
             </div>
           </div>
         <% end %>
-        </div>
+      </div>
     </div>
   <% end %>
   <div class="form-group">

--- a/app/views/network_events/show.html.erb
+++ b/app/views/network_events/show.html.erb
@@ -125,6 +125,7 @@
       <thead>
         <tr>
           <th>Name</th>
+          <th>Due Date</th>
           <th>Completed at</th>
           <th>Owner</th>
           <th></th>
@@ -134,7 +135,8 @@
       <tbody>
         <%= content_tag_for(:tr, @network_event.network_event_tasks) do |task| %>
           <td class="task_name"><%= task.name %></td>
-          <td class="task_completed_at"><%= if task.completed_at.present? then task.completed_at.in_time_zone("Central Time (US & Canada)").to_formatted_s(:long) end %></td>
+          <td class="task_due_date"><%= if task.due_date.present? then task.due_date.in_time_zone("Central Time (US & Canada)").strftime('%B %d, %Y') end %> </td>
+          <td class="task_completed_at"><%= if task.completed_at.present? then task.completed_at.in_time_zone("Central Time (US & Canada)").to_formatted_s(:long) end %> </td>
           <td class="task_owner"><%= task.owner.try(:email) %></td>
           <td class="task_mark">
             <% if not task.completed_at.present? %>

--- a/db/migrate/20170412132534_add_due_date_to_network_event_tasks.rb
+++ b/db/migrate/20170412132534_add_due_date_to_network_event_tasks.rb
@@ -1,0 +1,5 @@
+class AddDueDateToNetworkEventTasks < ActiveRecord::Migration
+  def change
+    add_column :network_event_tasks, :due_date, :datetime
+  end
+end

--- a/db/migrate/20170412163701_add_date_modifer_to_common_tasks.rb
+++ b/db/migrate/20170412163701_add_date_modifer_to_common_tasks.rb
@@ -1,0 +1,5 @@
+class AddDateModiferToCommonTasks < ActiveRecord::Migration
+  def change
+    add_column :common_tasks, :date_modifier, :string
+  end
+end

--- a/db/migrate/20170412164443_add_date_modifier_to_network_event_tasks.rb
+++ b/db/migrate/20170412164443_add_date_modifier_to_network_event_tasks.rb
@@ -1,0 +1,5 @@
+class AddDateModifierToNetworkEventTasks < ActiveRecord::Migration
+  def change
+    add_column :network_event_tasks, :date_modifier, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170322223833) do
+ActiveRecord::Schema.define(version: 20170412164443) do
 
   create_table "affiliations", force: :cascade do |t|
     t.integer  "member_id"
@@ -46,12 +45,12 @@ ActiveRecord::Schema.define(version: 20170322223833) do
   create_table "common_tasks", force: :cascade do |t|
     t.string   "name"
     t.integer  "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+    t.string   "date_modifier"
     t.integer  "owner_id"
+    t.index ["owner_id"], name: "index_common_tasks_on_owner_id"
   end
-
-  add_index "common_tasks", ["owner_id"], name: "index_common_tasks_on_owner_id"
 
   create_table "communications", force: :cascade do |t|
     t.string   "kind"
@@ -143,9 +142,8 @@ ActiveRecord::Schema.define(version: 20170322223833) do
     t.integer  "school_id"
     t.string   "mongo_id"
     t.integer  "identity_id"
+    t.index ["identity_id"], name: "index_members_on_identity_id"
   end
-
-  add_index "members", ["identity_id"], name: "index_members_on_identity_id"
 
   create_table "neighborhoods", force: :cascade do |t|
     t.string   "name"
@@ -172,12 +170,13 @@ ActiveRecord::Schema.define(version: 20170322223833) do
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.datetime "due_date"
+    t.string   "date_modifier"
     t.integer  "owner_id"
+    t.index ["common_task_id"], name: "index_network_event_tasks_on_common_task_id"
+    t.index ["network_event_id"], name: "index_network_event_tasks_on_network_event_id"
+    t.index ["owner_id"], name: "index_network_event_tasks_on_owner_id"
   end
-
-  add_index "network_event_tasks", ["common_task_id"], name: "index_network_event_tasks_on_common_task_id"
-  add_index "network_event_tasks", ["network_event_id"], name: "index_network_event_tasks_on_network_event_id"
-  add_index "network_event_tasks", ["owner_id"], name: "index_network_event_tasks_on_owner_id"
 
   create_table "network_events", force: :cascade do |t|
     t.string   "name"
@@ -193,9 +192,8 @@ ActiveRecord::Schema.define(version: 20170322223833) do
     t.text     "notes"
     t.string   "status"
     t.string   "mongo_id"
+    t.index ["program_id"], name: "index_network_events_on_program_id"
   end
-
-  add_index "network_events", ["program_id"], name: "index_network_events_on_program_id"
 
   create_table "organization_assignments", force: :cascade do |t|
     t.integer  "network_event_id"
@@ -297,10 +295,9 @@ ActiveRecord::Schema.define(version: 20170322223833) do
     t.datetime "created_at",                             null: false
     t.datetime "updated_at",                             null: false
     t.boolean  "admin",                  default: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
-
-  add_index "users", ["email"], name: "index_users_on_email", unique: true
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
 
   create_table "volunteer_assignments", force: :cascade do |t|
     t.integer  "member_id"


### PR DESCRIPTION
Added due date modifiers to tasks. These allow dynamic due dates and can be created
for both common and network event tasks. Connects to #470 