### PR TITLE
Fix foreign key problem in postgresql

### DIFF
--- a/db/migrate/20170322171523_add_owner_to_common_tasks.rb
+++ b/db/migrate/20170322171523_add_owner_to_common_tasks.rb
@@ -1,5 +1,5 @@
 class AddOwnerToCommonTasks < ActiveRecord::Migration
   def change
-    add_reference :common_tasks, :owner, index: true, foreign_key: true
+    add_reference :common_tasks, :owner, index: true, foreign_key: { to_table: :users }
   end
 end

--- a/db/migrate/20170322223833_add_owner_to_network_event_tasks.rb
+++ b/db/migrate/20170322223833_add_owner_to_network_event_tasks.rb
@@ -1,5 +1,5 @@
 class AddOwnerToNetworkEventTasks < ActiveRecord::Migration
   def change
-    add_reference :network_event_tasks, :owner, index: true, foreign_key: true
+    add_reference :network_event_tasks, :owner, index: true, foreign_key: { to_table: :users }
   end
 end


### PR DESCRIPTION
Since the CommonTask#owner and NetworkEventTask#owner references are actually referencing the users table then a :to_table option needs to be added to the foreign key attribute to keep it from trying to use a non-existant owners table rather than the appropriate users table.