### PR TITLE
Add check in links to the event page

### DIFF
--- a/app/views/network_events/show.html.erb
+++ b/app/views/network_events/show.html.erb
@@ -116,6 +116,16 @@
       <%= link_to 'Sign Up Volunteer', new_network_event_sign_up_path(:network_event_id => @network_event.id, :level => 'volunteer') %>
     </div>
   </dd>
+
+  <dt>Check In:</dt>
+  <dd>
+    <div class="check_in_attendee">
+      <%= link_to 'Check In Attendee', new_network_event_check_in_path(:network_event_id => @network_event.id, :level => 'attendee') %>
+    </div>
+    <div class="check_in_volunteer">
+      <%= link_to 'Check In Volunteer', new_network_event_check_in_path(:network_event_id => @network_event.id, :level => 'volunteer') %>
+    </div>
+  </dd>
 </dl>
 
 <h2>Event Task List</h2>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -131,6 +131,18 @@ Talent.create(name: 'Technology', user_id: user.id)
 Talent.create(name: 'Music', user_id: user.id)
 Talent.create(name: 'Sports', user_id: user.id)
 
+student_nell = Member.create(
+  first_name: 'Nell',
+  last_name: 'Student',
+  email: 'nell@example.com',
+  phone: '205 999-9999',
+  neighborhoods: [ensley],
+  school: carver,
+  graduating_class: class_of_2017,
+  cohorts: [gear_up],
+  user_id: user.id
+)
+
 network_event = nil
 Location.all.each do |location|
   Program.all.each do |program|


### PR DESCRIPTION
The main event check in navigation only allows events from today forward to
be checked into.  Sometimes event checkins are done after the event.  Check in
links have been added to the event page so that checkins can be done from any
event.