### PR TITLE
Fix select2 not targeting inputs on navigation

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,3 +19,7 @@
 //= require bootstrap-datetimepicker
 //= require select2-full
 //= require zeroclipboard
+
+$(document).on('turbolinks:render', function() {
+  $('.select2').select2();
+});


### PR DESCRIPTION
Turbolinks navigation messes with select2's default behavior.
We have to add a an explicit call to `.select2` when Turbolinks
has finished rendering the new content.

Screenshot of the problem:
<img width="693" alt="screen shot 2017-06-14 at 12 24 39 pm" src="https://user-images.githubusercontent.com/4067/27145700-564319bc-50fc-11e7-8ad7-f5bc11ea7ad9.png">

Fixes #489