### PR TITLE
Fixed error on quick search

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -76,7 +76,7 @@ class MembersController < ApplicationController
         joins(:identity).
         where(identities: {id: params[:identity_ids]})
       end
-
+      
       # limit the size of xml_http_request? responses
       if request.xhr?
         members = members.limit(25)
@@ -84,7 +84,11 @@ class MembersController < ApplicationController
 
       # Filter members by search term
       if params[:q].present?
-        members = members.search(params[:q])
+        query = params[:q]
+        if request.xhr?
+          query = query[:term]
+        end
+        members = members.search(query)
       end
 
       # Filter members by school.


### PR DESCRIPTION
When a member search is done from the member index page the :q parameter
is the text typed in to the search box.  When a member search is done from
an autocomplete select box via xhr the :q parameter is a hash with the text
in a :terms key.  A recent change treated both scenarios as a string value
which resulted in an error in the autocomplete.