### PR TITLE
Add index page and filtering for event tasks

### DIFF
--- a/app/assets/javascripts/network_event_tasks.coffee
+++ b/app/assets/javascripts/network_event_tasks.coffee
@@ -1,0 +1,22 @@
+$(document).on 'ready page:load', ->
+  
+  # initialize and link datepickers
+  $ ->
+    $('#startdatepicker').datetimepicker
+      useCurrent: false
+      format: 'ddd MMMM DD YYYY'
+    $('#enddatepicker').datetimepicker
+      useCurrent: false
+      format: 'ddd MMMM DD YYYY'
+    $('#startdatepicker').on 'dp.change', (e) ->
+      $('#enddatepicker').data('DateTimePicker').minDate e.date
+      return
+    $('#enddatepicker').on 'dp.change', (e) ->
+      $('#startdatepicker').data('DateTimePicker').maxDate e.date
+      return
+    return
+    
+  $('tr.network_event_task').on 'ajax:success', (event, data) ->
+    $(this).children('td.completed_at').html(data.formatted_date)
+    
+    

--- a/app/assets/javascripts/network_events.coffee
+++ b/app/assets/javascripts/network_events.coffee
@@ -43,3 +43,8 @@ $(document).on 'ready page:load', ->
       $("#new-task-form").hide()
       
     
+  # Task completion on event show page
+  $('tr.network_event_task').on 'ajax:success', (event, data) ->
+    $(this).children('td.task_completed_at').html(data.formatted_date)
+    $(this).children("td.task_mark").find(".task_button").replaceWith("Completed");
+    $("#completed-count").text( parseInt( $("#completed-count").text() ) + 1);

--- a/app/controllers/network_event_tasks_controller.rb
+++ b/app/controllers/network_event_tasks_controller.rb
@@ -14,11 +14,19 @@ class NetworkEventTasksController < ApplicationController
     end
   end
   
+  def index
+    @network_event_tasks = filtered_event_tasks.page params[:page]
+    @status_filter = params[:status_filter]
+    @start_date = params[:start_date]
+    @end_date = params[:end_date]
+  end
+  
   def update
     @network_event_task = NetworkEventTask.find(params[:id])
     respond_to do |format|
       if @network_event_task.update(network_event_task_params)
-        format.js {}
+        format.json { render json:  { network_event_task: @network_event_task, formatted_date: 
+          @network_event_task.completed_at.in_time_zone("Central Time (US & Canada)").strftime(' %a, %B %e %Y') }}
       else
         format.json { render json: @network_event_task.errors, status: :unprocessable_entity }
       end
@@ -34,6 +42,45 @@ class NetworkEventTasksController < ApplicationController
   end
   
   private
+  
+  def filtered_event_tasks
+    tasks = NetworkEventTask.
+      includes(:owner, :network_event, :common_task).
+      order("due_date IS NULL, due_date ASC")
+      
+    # Filter tasks by completion
+    if params[:status_filter] == 'uncompleted_only'
+      tasks = tasks.where(completed_at: nil);
+    elsif params[:status_filter] == 'completed_only'
+      tasks = tasks.where.not(completed_at: nil)
+    elsif params[:status_filter] == 'show_all'
+      tasks = tasks
+    end
+    
+    # Filter by due date
+    if params[:start_date].present? && params[:end_date].present?
+      tasks = tasks.in_date_range(params[:start_date], params[:end_date])
+    end
+    
+    # Filter tasks by owner
+    if params[:owner_ids].present?
+      tasks = tasks.
+        where(:owner_id => params[:owner_ids])
+    end
+        
+    # Filter tasks by common task category
+    if params[:common_task_ids].present?
+      tasks = tasks.
+        where(:common_task_id => params[:common_task_ids])
+    end
+    
+    # Fitler tasks by network event
+    if params[:network_event_ids].present?
+      tasks = tasks.
+        where(:network_event_id => params[:network_event_ids])
+    end
+    tasks
+  end
   
   def network_event_task_params
     params.require(:network_event_task).permit(:name, :network_event_id, :common_task_id, :completed_at, :owner_id, :due_date, :date_modifier) 

--- a/app/models/network_event_task.rb
+++ b/app/models/network_event_task.rb
@@ -5,4 +5,11 @@ class NetworkEventTask < ApplicationRecord
   belongs_to :common_task
   
   validates_presence_of :name
+  
+  def self.in_date_range(start_date, end_date)
+    start_date = Date.strptime(start_date, '%A %B %d %Y')
+    end_date = Date.strptime(end_date, '%A %B %d %Y')
+    where(due_date: [start_date.beginning_of_day..end_date.end_of_day, nil])
+  end
+  
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,6 +31,7 @@
                 <li><%= link_to('Members', members_path) %></li>
                 <li><%= link_to('Events', network_events_path) %></li>
                 <li><%= link_to('Actions', network_actions_path) %></li>
+                <li><%= link_to('Event Tasks', network_event_tasks_path) %></li>
               </ul>
             <% end %>
             <ul class="nav navbar-nav navbar-right">

--- a/app/views/network_event_tasks/index.html.erb
+++ b/app/views/network_event_tasks/index.html.erb
@@ -1,0 +1,127 @@
+<div class="page-header">
+  <h1>Listing event tasks</h1>
+  
+<%= form_tag network_event_tasks_path, :method => :get, class: "form-horizontal" do %>
+  <div class="container">
+    <div class="form-group">
+      <div class="col-md-12">
+        <%= label_tag :status_filter_show_all, "Show all" %>
+        <%= radio_button_tag :status_filter, :show_all, !@status_filter.present? || @status_filter.eql?('show_all') %>
+        <%= label_tag :status_filter_uncompleted_only, "Uncompleted only" %>
+        <%= radio_button_tag :status_filter, :uncompleted_only, @status_filter.eql?('uncompleted_only') %>
+        <%= label_tag :status_filter_completed_only, "Completed only" %>
+        <%= radio_button_tag :status_filter, :completed_only, @status_filter.eql?('completed_only') %>
+      </div>
+    </div>
+    <div class='col-md-5'>
+        <div class="form-group">
+            <div class='input-group date' id='startdatepicker'>
+                <%= text_field_tag :start_date, @start_date, class: "form-control" %>
+                <span class="input-group-addon">
+                    <span class="glyphicon glyphicon-calendar"></span>
+                </span>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-2">
+      Through
+    </div>
+    <div class='col-md-5'>
+        <div class="form-group">
+            <div class='input-group date' id='enddatepicker'>
+                <%= text_field_tag :end_date, @end_date, class: "form-control" %>
+                <span class="input-group-addon">
+                    <span class="glyphicon glyphicon-calendar"></span>
+                </span>
+            </div>
+        </div>
+    </div>
+    <div class="form-group">
+      <div class="col-md-12">
+        <%= select_tag :network_event_ids, 
+              options_from_collection_for_select(
+                NetworkEvent.order(:name).all, 
+                :id, 
+                :name,
+                params[:network_event_ids]
+              ),
+              class: "select2 form-control", 
+              multiple: true, 
+              data: { placeholder: 'Filter by event' }  %>
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="col-md-12">
+        <%= select_tag :owner_ids, 
+              options_from_collection_for_select(
+                User.order(:email).all, 
+                :id, 
+                :email,
+                params[:owner_ids]
+              ),
+              class: "select2 form-control", 
+              multiple: true, 
+              data: { placeholder: 'Filter by task owner' }  %>
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="col-md-12">
+        <%= select_tag :common_task_ids, 
+              options_from_collection_for_select(
+                CommonTask.order(:name).all, 
+                :id, 
+                :name,
+                params[:common_task_ids]
+              ),
+              class: "select2 form-control", 
+              multiple: true, 
+              data: { placeholder: 'Filter by common task' }  %>
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="col-md-12">
+        <%= submit_tag "Filter tasks", class: "btn btn-secondary"%>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+</div>
+
+<div class="table-responsive">
+  <table class="table table-striped table-bordered table-hover">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Network event</th>
+        <th>Owner</th>
+        <th>Due date</th>
+        <th>Common task</th>
+        <th>Completed on</th>
+        <th></th>
+      </tr>
+    </thead>
+
+    <tbody> 
+      <%= content_tag_for(:tr, @network_event_tasks) do |task| %>
+        <td><%= task.name %></td>
+        <td><%= link_to(task.network_event.name, network_event_path(task.network_event)) if task.network_event %></td>
+        <td><%= task.owner.try(:email) %></td>
+        <td><%= task.due_date.in_time_zone("Central Time (US & Canada)").strftime(' %a, %B %e %Y') if task.due_date %></td>
+        <td><%= task.common_task.try(:name) %></td>
+        <td class="completed_at"><%= task.completed_at.in_time_zone("Central Time (US & Canada)").strftime(' %a, %B %e %Y') if task.completed_at %></td>
+        <td>
+          <% if task.completed_at.present? %>
+            Completed
+          <% else %>
+            <%= button_to("Mark completed",
+                  network_event_task_path(task), remote: true, method: :patch, 
+                  name: "task_button", class: "btn btn-primary",
+                  params: { :"network_event_task[completed_at]" => Time.now }) %>
+          <% end %>
+        </td>
+      <% end %>
+    </tbody>
+  </table>
+  <%= paginate @network_event_tasks %>
+</div>

--- a/app/views/network_events/show.html.erb
+++ b/app/views/network_events/show.html.erb
@@ -152,11 +152,7 @@
           <td class="task_mark">
             <% if not task.completed_at.present? %>
               <%= button_to("Mark Completed", network_event_task_path(task) , remote: true, method: :patch, name: "task_button", class:"btn btn-primary task_button",
-                            params: { :"network_event_task[name]" => task.name,
-                                      :"network_event_task[network_event_id]" => task.network_event_id,
-                                      :"network_event_task[common_task_id]" => task.common_task_id,
-                                      :"network_event_task[owner_id]" => task.owner_id,
-                                      :"network_event_task[completed_at]" => Time.now }) %>
+                            params: { :"network_event_task[completed_at]" => Time.now }) %>
             <% else %>
               Completed 
             <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   resources :graduating_classes
   resources :network_actions
   resources :programs
-  resources :network_event_tasks, only: [:create, :update, :destroy]
+  resources :network_event_tasks, only: [:create, :index, :update, :destroy]
   
   resources :network_events do
     resources :sign_ups, only: [:new, :show, :create, :edit, :update]

--- a/test/controllers/network_event_tasks_controller_test.rb
+++ b/test/controllers/network_event_tasks_controller_test.rb
@@ -8,6 +8,56 @@ class NetworkEventTasksControllerTest < ActionController::TestCase
     sign_in users(:one)
   end
 
+  test "should get index" do
+    get :index
+    assert_response :success
+    assert_not_nil assigns(:network_event_tasks)
+  end
+
+  test "should get index with uncompleted tasks" do
+    get :index, params: {
+      status_filter: "uncompleted_only",
+      commit: "Filter tasks"
+    }
+    assert_response :success
+    assert assigns(:network_event_tasks).present?
+    assert_equal 1, assigns(:network_event_tasks).length
+    assert_includes assigns(:network_event_tasks), network_event_tasks(:uncompleted_task)
+  end
+
+  test "should get index with tasks inside date range" do
+    get :index, params: {
+      start_date: "Friday September 2 2016",
+      end_date: "Saturday September 3 2016",
+      commit: "Filter tasks"
+    }
+    assert_response :success
+    assert assigns(:network_event_tasks).present?
+    assert_includes assigns(:network_event_tasks), network_event_tasks(:two)
+  end
+
+  test "should get index with common task id of one" do
+    get :index, params: {
+      common_task_ids: [common_tasks(:one).id],
+      commit: "Filter tasks"
+    }
+
+    assert_response :success
+    assert assigns(:network_event_tasks).present?
+    assert_includes assigns(:network_event_tasks), network_event_tasks(:one)
+  end
+
+  test "should get index with owner id of two" do
+    get :index, params: {
+      owner_ids: [users(:two).id],
+      commit: "Filter events"
+    }
+
+    assert_response :success
+    assert assigns(:network_event_tasks).present?
+    assert_includes assigns(:network_event_tasks), network_event_tasks(:two)
+  end
+  
   test "should update network event task" do
     patch :update, xhr: true, params: {
       id: @network_event_task,

--- a/test/fixtures/network_event_tasks.yml
+++ b/test/fixtures/network_event_tasks.yml
@@ -5,18 +5,20 @@ one:
   network_event: tuggle_network 
   common_task: one
   completed_at: 2016-08-01 01:00:00
+  owner: one
   user: one
 
 two:
   name: MyString
   network_event: carver_tour 
   common_task: two
-  completed_at: 2016-08-01 01:00:00
+  completed_at: 2016-09-02 01:00:00
+  owner: two
   user: one
   
-three:
+uncompleted_task:
   name: MyString
   network_event: dateless_event 
   common_task: two
-  completed_at: 2016-08-01 01:00:00
+  completed_at: null
   user: one


### PR DESCRIPTION
Added an index page for event tasks. The page can be filtered by completion, due date,
event, owner, and common task. #492 