### PR TITLE
Fix table identity error on event show page

### DIFF
--- a/app/views/network_events/show.html.erb
+++ b/app/views/network_events/show.html.erb
@@ -208,7 +208,7 @@
         <td><%= link_to invitee.name, invitee %></td>
         <td><%= invitee.email %></td>
         <td><%= invitee.phone %></td>
-        <td><%= invitee.identity %></td>
+        <td><%= invitee.identity.name %></td>
       <% end %>
     </tbody>
   </table>
@@ -233,7 +233,7 @@
         <td><%= link_to participant.name, participant %></td>
         <td><%= participant.email %></td>
         <td><%= participant.phone %></td>
-        <td><%= participant.identity %></td>
+        <td><%= participant.identity.name %></td>
       <% end %>
     </tbody>
   </table>


### PR DESCRIPTION
- Fixed indentity label on events page in participants and invitees table
Issue #488 