### PR TITLE
Fixed migration to support with Rails 5.1

### DIFF
--- a/db/migrate/20160614014907_devise_create_users.rb
+++ b/db/migrate/20160614014907_devise_create_users.rb
@@ -1,4 +1,4 @@
-class DeviseCreateUsers < ActiveRecord::Migration
+class DeviseCreateUsers < ActiveRecord::Migration[5.1]
   def change
     create_table :users do |t|
       ## Database authenticatable

--- a/db/migrate/20160618155617_create_locations.rb
+++ b/db/migrate/20160618155617_create_locations.rb
@@ -1,4 +1,4 @@
-class CreateLocations < ActiveRecord::Migration
+class CreateLocations < ActiveRecord::Migration[5.1]
   def change
     create_table :locations do |t|
       t.string :name

--- a/db/migrate/20160618224637_create_members.rb
+++ b/db/migrate/20160618224637_create_members.rb
@@ -1,4 +1,4 @@
-class CreateMembers < ActiveRecord::Migration
+class CreateMembers < ActiveRecord::Migration[5.1]
   def change
     create_table :members do |t|
       t.string :first_name

--- a/db/migrate/20160620015956_create_network_events.rb
+++ b/db/migrate/20160620015956_create_network_events.rb
@@ -1,4 +1,4 @@
-class CreateNetworkEvents < ActiveRecord::Migration
+class CreateNetworkEvents < ActiveRecord::Migration[5.1]
   def change
     create_table :network_events do |t|
       t.string :name

--- a/db/migrate/20160622170010_create_programs.rb
+++ b/db/migrate/20160622170010_create_programs.rb
@@ -1,4 +1,4 @@
-class CreatePrograms < ActiveRecord::Migration
+class CreatePrograms < ActiveRecord::Migration[5.1]
   def change
     create_table :programs do |t|
       t.string :name

--- a/db/migrate/20160622224629_add_programs_to_network_events.rb
+++ b/db/migrate/20160622224629_add_programs_to_network_events.rb
@@ -1,4 +1,4 @@
-class AddProgramsToNetworkEvents < ActiveRecord::Migration
+class AddProgramsToNetworkEvents < ActiveRecord::Migration[5.1]
   def change
     add_reference :network_events, :program, index: true, foreign_key: true
   end

--- a/db/migrate/20160622225354_remove_event_type_from_network_events.rb
+++ b/db/migrate/20160622225354_remove_event_type_from_network_events.rb
@@ -1,4 +1,4 @@
-class RemoveEventTypeFromNetworkEvents < ActiveRecord::Migration
+class RemoveEventTypeFromNetworkEvents < ActiveRecord::Migration[5.1]
   def up
     remove_column :network_events, :event_type, :string
   end

--- a/db/migrate/20160623202242_add_abbreviation_to_programs.rb
+++ b/db/migrate/20160623202242_add_abbreviation_to_programs.rb
@@ -1,4 +1,4 @@
-class AddAbbreviationToPrograms < ActiveRecord::Migration
+class AddAbbreviationToPrograms < ActiveRecord::Migration[5.1]
   def change
     add_column :programs, :abbreviation, :string
   end

--- a/db/migrate/20160710130433_create_organizations.rb
+++ b/db/migrate/20160710130433_create_organizations.rb
@@ -1,4 +1,4 @@
-class CreateOrganizations < ActiveRecord::Migration
+class CreateOrganizations < ActiveRecord::Migration[5.1]
   def change
     create_table :organizations do |t|
       t.string :name

--- a/db/migrate/20160725011959_create_network_actions.rb
+++ b/db/migrate/20160725011959_create_network_actions.rb
@@ -1,4 +1,4 @@
-class CreateNetworkActions < ActiveRecord::Migration
+class CreateNetworkActions < ActiveRecord::Migration[5.1]
   def change
     create_table :network_actions do |t|
       t.integer :actor_id

--- a/db/migrate/20160725012145_create_matches.rb
+++ b/db/migrate/20160725012145_create_matches.rb
@@ -1,4 +1,4 @@
-class CreateMatches < ActiveRecord::Migration
+class CreateMatches < ActiveRecord::Migration[5.1]
   def change
     create_table :matches do |t|
       t.integer :network_action_id

--- a/db/migrate/20160726171821_add_graduation_year_to_members.rb
+++ b/db/migrate/20160726171821_add_graduation_year_to_members.rb
@@ -1,4 +1,4 @@
-class AddGraduationYearToMembers < ActiveRecord::Migration
+class AddGraduationYearToMembers < ActiveRecord::Migration[5.1]
   def change
     add_column :members, :graduation_year, :integer
   end

--- a/db/migrate/20160727164903_create_affiliations.rb
+++ b/db/migrate/20160727164903_create_affiliations.rb
@@ -1,9 +1,9 @@
-class CreateAffiliations < ActiveRecord::Migration
+class CreateAffiliations < ActiveRecord::Migration[5.1]
   def change
     create_table :affiliations do |t|
       t.integer :member_id
       t.integer :organization_id
-      
+
       t.timestamps null: false
     end
   end

--- a/db/migrate/20160731213129_add_duration_to_network_events.rb
+++ b/db/migrate/20160731213129_add_duration_to_network_events.rb
@@ -1,4 +1,4 @@
-class AddDurationToNetworkEvents < ActiveRecord::Migration
+class AddDurationToNetworkEvents < ActiveRecord::Migration[5.1]
   def change
     add_column :network_events, :duration, :integer, default: 60
   end

--- a/db/migrate/20160804154639_add_address_details_to_locations.rb
+++ b/db/migrate/20160804154639_add_address_details_to_locations.rb
@@ -1,4 +1,4 @@
-class AddAddressDetailsToLocations < ActiveRecord::Migration
+class AddAddressDetailsToLocations < ActiveRecord::Migration[5.1]
   def change
     add_column :locations, :address_one, :string
     add_column :locations, :address_two, :string

--- a/db/migrate/20160808011414_add_org_to_event.rb
+++ b/db/migrate/20160808011414_add_org_to_event.rb
@@ -1,4 +1,4 @@
-class AddOrgToEvent < ActiveRecord::Migration
+class AddOrgToEvent < ActiveRecord::Migration[5.1]
   def change
     add_column :network_events, :organization_id, :integer
   end

--- a/db/migrate/20160808021542_create_site_assignments.rb
+++ b/db/migrate/20160808021542_create_site_assignments.rb
@@ -1,4 +1,4 @@
-class CreateSiteAssignments < ActiveRecord::Migration
+class CreateSiteAssignments < ActiveRecord::Migration[5.1]
   def change
     create_table :site_assignments do |t|
       t.integer :network_event_id

--- a/db/migrate/20160809015300_create_volunteer_assignments.rb
+++ b/db/migrate/20160809015300_create_volunteer_assignments.rb
@@ -1,4 +1,4 @@
-class CreateVolunteerAssignments < ActiveRecord::Migration
+class CreateVolunteerAssignments < ActiveRecord::Migration[5.1]
   def change
     create_table :volunteer_assignments do |t|
       t.integer :member_id

--- a/db/migrate/20160810131614_create_graduating_classes.rb
+++ b/db/migrate/20160810131614_create_graduating_classes.rb
@@ -1,4 +1,4 @@
-class CreateGraduatingClasses < ActiveRecord::Migration
+class CreateGraduatingClasses < ActiveRecord::Migration[5.1]
   def change
     create_table :graduating_classes do |t|
       t.integer :year

--- a/db/migrate/20160814133119_create_graduating_class_assignments.rb
+++ b/db/migrate/20160814133119_create_graduating_class_assignments.rb
@@ -1,4 +1,4 @@
-class CreateGraduatingClassAssignments < ActiveRecord::Migration
+class CreateGraduatingClassAssignments < ActiveRecord::Migration[5.1]
   def change
     create_table :graduating_class_assignments do |t|
       t.integer :graduating_class_id

--- a/db/migrate/20160815023531_remove_organization_from_event.rb
+++ b/db/migrate/20160815023531_remove_organization_from_event.rb
@@ -1,4 +1,4 @@
-class RemoveOrganizationFromEvent < ActiveRecord::Migration
+class RemoveOrganizationFromEvent < ActiveRecord::Migration[5.1]
   def change
     remove_column :network_events, :organization_id
   end

--- a/db/migrate/20160815023831_create_organization_assignments.rb
+++ b/db/migrate/20160815023831_create_organization_assignments.rb
@@ -1,4 +1,4 @@
-class CreateOrganizationAssignments < ActiveRecord::Migration
+class CreateOrganizationAssignments < ActiveRecord::Migration[5.1]
   def change
     create_table :organization_assignments do |t|
       t.integer :network_event_id

--- a/db/migrate/20160815233719_change_grad_year_on_members.rb
+++ b/db/migrate/20160815233719_change_grad_year_on_members.rb
@@ -1,4 +1,4 @@
-class ChangeGradYearOnMembers < ActiveRecord::Migration
+class ChangeGradYearOnMembers < ActiveRecord::Migration[5.1]
   def change
     rename_column :members, :graduation_year, :graduating_class_id
   end

--- a/db/migrate/20160816020706_create_cohorts.rb
+++ b/db/migrate/20160816020706_create_cohorts.rb
@@ -1,4 +1,4 @@
-class CreateCohorts < ActiveRecord::Migration
+class CreateCohorts < ActiveRecord::Migration[5.1]
   def change
     create_table :cohorts do |t|
       t.string :name

--- a/db/migrate/20160816022321_create_schools.rb
+++ b/db/migrate/20160816022321_create_schools.rb
@@ -1,4 +1,4 @@
-class CreateSchools < ActiveRecord::Migration
+class CreateSchools < ActiveRecord::Migration[5.1]
   def change
     create_table :schools do |t|
       t.string :name

--- a/db/migrate/20160816170443_create_talents.rb
+++ b/db/migrate/20160816170443_create_talents.rb
@@ -1,4 +1,4 @@
-class CreateTalents < ActiveRecord::Migration
+class CreateTalents < ActiveRecord::Migration[5.1]
   def change
     create_table :talents do |t|
       t.string :name

--- a/db/migrate/20160816170934_create_talent_assignments.rb
+++ b/db/migrate/20160816170934_create_talent_assignments.rb
@@ -1,4 +1,4 @@
-class CreateTalentAssignments < ActiveRecord::Migration
+class CreateTalentAssignments < ActiveRecord::Migration[5.1]
   def change
     create_table :talent_assignments do |t|
       t.integer :talent_id

--- a/db/migrate/20160817015648_rename_school_assignment.rb
+++ b/db/migrate/20160817015648_rename_school_assignment.rb
@@ -1,4 +1,4 @@
-class RenameSchoolAssignment < ActiveRecord::Migration
+class RenameSchoolAssignment < ActiveRecord::Migration[5.1]
   def change
     rename_table :school_assignments, :school_contact_assignments
   end

--- a/db/migrate/20160817021519_rename_site_assignment.rb
+++ b/db/migrate/20160817021519_rename_site_assignment.rb
@@ -1,4 +1,4 @@
-class RenameSiteAssignment < ActiveRecord::Migration
+class RenameSiteAssignment < ActiveRecord::Migration[5.1]
   def change
     rename_table :site_assignments, :site_contact_assignments
   end

--- a/db/migrate/20160817112254_remove_talent_from_members.rb
+++ b/db/migrate/20160817112254_remove_talent_from_members.rb
@@ -1,4 +1,4 @@
-class RemoveTalentFromMembers < ActiveRecord::Migration
+class RemoveTalentFromMembers < ActiveRecord::Migration[5.1]
   def change
     remove_column :members, :talent
   end

--- a/db/migrate/20160817162105_create_neighborhoods.rb
+++ b/db/migrate/20160817162105_create_neighborhoods.rb
@@ -1,4 +1,4 @@
-class CreateNeighborhoods < ActiveRecord::Migration
+class CreateNeighborhoods < ActiveRecord::Migration[5.1]
   def change
     create_table :neighborhoods do |t|
       t.string :name

--- a/db/migrate/20160817164256_create_school_assignments.rb
+++ b/db/migrate/20160817164256_create_school_assignments.rb
@@ -1,4 +1,4 @@
-class CreateSchoolAssignments < ActiveRecord::Migration
+class CreateSchoolAssignments < ActiveRecord::Migration[5.1]
   def change
     create_table :school_assignments do |t|
       t.integer :network_event_id

--- a/db/migrate/20160817171426_create_cohort_assignments.rb
+++ b/db/migrate/20160817171426_create_cohort_assignments.rb
@@ -1,4 +1,4 @@
-class CreateCohortAssignments < ActiveRecord::Migration
+class CreateCohortAssignments < ActiveRecord::Migration[5.1]
   def change
     create_table :cohort_assignments do |t|
       t.integer :network_event_id

--- a/db/migrate/20160822211424_create_residences.rb
+++ b/db/migrate/20160822211424_create_residences.rb
@@ -1,4 +1,4 @@
-class CreateResidences < ActiveRecord::Migration
+class CreateResidences < ActiveRecord::Migration[5.1]
   def change
     create_table :residences do |t|
       t.integer :member_id

--- a/db/migrate/20160822221834_create_extracurricular_activities.rb
+++ b/db/migrate/20160822221834_create_extracurricular_activities.rb
@@ -1,4 +1,4 @@
-class CreateExtracurricularActivities < ActiveRecord::Migration
+class CreateExtracurricularActivities < ActiveRecord::Migration[5.1]
   def change
     create_table :extracurricular_activities do |t|
       t.string :name

--- a/db/migrate/20160822231746_create_extracurricular_activity_assignments.rb
+++ b/db/migrate/20160822231746_create_extracurricular_activity_assignments.rb
@@ -1,4 +1,4 @@
-class CreateExtracurricularActivityAssignments < ActiveRecord::Migration
+class CreateExtracurricularActivityAssignments < ActiveRecord::Migration[5.1]
   def change
     create_table :extracurricular_activity_assignments do |t|
       t.integer :member_id

--- a/db/migrate/20160823022238_add_admin_role.rb
+++ b/db/migrate/20160823022238_add_admin_role.rb
@@ -1,4 +1,4 @@
-class AddAdminRole < ActiveRecord::Migration
+class AddAdminRole < ActiveRecord::Migration[5.1]
   def change
     add_column :users, :admin, :boolean, default: false
   end

--- a/db/migrate/20160823032921_create_participations.rb
+++ b/db/migrate/20160823032921_create_participations.rb
@@ -1,4 +1,4 @@
-class CreateParticipations < ActiveRecord::Migration
+class CreateParticipations < ActiveRecord::Migration[5.1]
   def change
     create_table :participations do |t|
       t.string :level

--- a/db/migrate/20160824173532_add_school_id_to_members.rb
+++ b/db/migrate/20160824173532_add_school_id_to_members.rb
@@ -1,4 +1,4 @@
-class AddSchoolIdToMembers < ActiveRecord::Migration
+class AddSchoolIdToMembers < ActiveRecord::Migration[5.1]
   def change
     add_column :members, :school_id, :integer
   end

--- a/db/migrate/20160824180110_create_cohortians.rb
+++ b/db/migrate/20160824180110_create_cohortians.rb
@@ -1,4 +1,4 @@
-class CreateCohortians < ActiveRecord::Migration
+class CreateCohortians < ActiveRecord::Migration[5.1]
   def change
     create_table :cohortians do |t|
       t.integer :member_id

--- a/db/migrate/20160824212724_remove_affiliation_from_member.rb
+++ b/db/migrate/20160824212724_remove_affiliation_from_member.rb
@@ -1,4 +1,4 @@
-class RemoveAffiliationFromMember < ActiveRecord::Migration
+class RemoveAffiliationFromMember < ActiveRecord::Migration[5.1]
   def change
     remove_column :members, :affiliation
   end

--- a/db/migrate/20161102165820_create_communications.rb
+++ b/db/migrate/20161102165820_create_communications.rb
@@ -1,4 +1,4 @@
-class CreateCommunications < ActiveRecord::Migration
+class CreateCommunications < ActiveRecord::Migration[5.1]
   def change
     create_table :communications do |t|
       t.string :kind

--- a/db/migrate/20161116174039_add_mongo_id_to_member.rb
+++ b/db/migrate/20161116174039_add_mongo_id_to_member.rb
@@ -1,4 +1,4 @@
-class AddMongoIdToMember < ActiveRecord::Migration
+class AddMongoIdToMember < ActiveRecord::Migration[5.1]
   def change
     add_column :members, :mongo_id, :string
   end

--- a/db/migrate/20161130192947_add_fields_to_network_events.rb
+++ b/db/migrate/20161130192947_add_fields_to_network_events.rb
@@ -1,4 +1,4 @@
-class AddFieldsToNetworkEvents < ActiveRecord::Migration
+class AddFieldsToNetworkEvents < ActiveRecord::Migration[5.1]
   def change
     add_column :network_events, :needs_transport, :boolean
     add_column :network_events, :transport_ordered_on, :datetime

--- a/db/migrate/20161130205854_add_notes_to_network_events.rb
+++ b/db/migrate/20161130205854_add_notes_to_network_events.rb
@@ -1,4 +1,4 @@
-class AddNotesToNetworkEvents < ActiveRecord::Migration
+class AddNotesToNetworkEvents < ActiveRecord::Migration[5.1]
   def change
     add_column :network_events, :notes, :text
   end

--- a/db/migrate/20161229194057_add_status_to_event.rb
+++ b/db/migrate/20161229194057_add_status_to_event.rb
@@ -1,4 +1,4 @@
-class AddStatusToEvent < ActiveRecord::Migration
+class AddStatusToEvent < ActiveRecord::Migration[5.1]
   def change
     add_column :network_events, :status, :string
   end

--- a/db/migrate/20170108211004_add_mongo_id_to_network_event.rb
+++ b/db/migrate/20170108211004_add_mongo_id_to_network_event.rb
@@ -1,4 +1,4 @@
-class AddMongoIdToNetworkEvent < ActiveRecord::Migration
+class AddMongoIdToNetworkEvent < ActiveRecord::Migration[5.1]
   def change
     add_column :network_events, :mongo_id, :string
   end

--- a/db/migrate/20170125181232_create_common_tasks.rb
+++ b/db/migrate/20170125181232_create_common_tasks.rb
@@ -1,4 +1,4 @@
-class CreateCommonTasks < ActiveRecord::Migration
+class CreateCommonTasks < ActiveRecord::Migration[5.1]
   def change
     create_table :common_tasks do |t|
       t.string :name

--- a/db/migrate/20170201182957_create_network_event_tasks.rb
+++ b/db/migrate/20170201182957_create_network_event_tasks.rb
@@ -1,4 +1,4 @@
-class CreateNetworkEventTasks < ActiveRecord::Migration
+class CreateNetworkEventTasks < ActiveRecord::Migration[5.1]
   def change
     create_table :network_event_tasks do |t|
       t.string :name

--- a/db/migrate/20170206135401_create_identities.rb
+++ b/db/migrate/20170206135401_create_identities.rb
@@ -1,4 +1,4 @@
-class CreateIdentities < ActiveRecord::Migration
+class CreateIdentities < ActiveRecord::Migration[5.1]
   def change
     create_table :identities do |t|
       t.string :name

--- a/db/migrate/20170218041732_add_identityid_to_members.rb
+++ b/db/migrate/20170218041732_add_identityid_to_members.rb
@@ -1,4 +1,4 @@
-class AddIdentityidToMembers < ActiveRecord::Migration
+class AddIdentityidToMembers < ActiveRecord::Migration[5.1]
   def change
     add_reference :members, :identity, index: true, foreign_key: true
   end

--- a/db/migrate/20170322163313_add_timestamps_to_network_event_tasks.rb
+++ b/db/migrate/20170322163313_add_timestamps_to_network_event_tasks.rb
@@ -1,4 +1,4 @@
-class AddTimestampsToNetworkEventTasks < ActiveRecord::Migration
+class AddTimestampsToNetworkEventTasks < ActiveRecord::Migration[5.1]
   def change
     add_column :network_event_tasks, :created_at, :datetime
     add_column :network_event_tasks, :updated_at, :datetime

--- a/db/migrate/20170322171523_add_owner_to_common_tasks.rb
+++ b/db/migrate/20170322171523_add_owner_to_common_tasks.rb
@@ -1,4 +1,4 @@
-class AddOwnerToCommonTasks < ActiveRecord::Migration
+class AddOwnerToCommonTasks < ActiveRecord::Migration[5.1]
   def change
     add_reference :common_tasks, :owner, index: true, foreign_key: { to_table: :users }
   end

--- a/db/migrate/20170322223833_add_owner_to_network_event_tasks.rb
+++ b/db/migrate/20170322223833_add_owner_to_network_event_tasks.rb
@@ -1,4 +1,4 @@
-class AddOwnerToNetworkEventTasks < ActiveRecord::Migration
+class AddOwnerToNetworkEventTasks < ActiveRecord::Migration[5.1]
   def change
     add_reference :network_event_tasks, :owner, index: true, foreign_key: { to_table: :users }
   end

--- a/db/migrate/20170412132534_add_due_date_to_network_event_tasks.rb
+++ b/db/migrate/20170412132534_add_due_date_to_network_event_tasks.rb
@@ -1,4 +1,4 @@
-class AddDueDateToNetworkEventTasks < ActiveRecord::Migration
+class AddDueDateToNetworkEventTasks < ActiveRecord::Migration[5.1]
   def change
     add_column :network_event_tasks, :due_date, :datetime
   end

--- a/db/migrate/20170412163701_add_date_modifer_to_common_tasks.rb
+++ b/db/migrate/20170412163701_add_date_modifer_to_common_tasks.rb
@@ -1,4 +1,4 @@
-class AddDateModiferToCommonTasks < ActiveRecord::Migration
+class AddDateModiferToCommonTasks < ActiveRecord::Migration[5.1]
   def change
     add_column :common_tasks, :date_modifier, :string
   end

--- a/db/migrate/20170412164443_add_date_modifier_to_network_event_tasks.rb
+++ b/db/migrate/20170412164443_add_date_modifier_to_network_event_tasks.rb
@@ -1,4 +1,4 @@
-class AddDateModifierToNetworkEventTasks < ActiveRecord::Migration
+class AddDateModifierToNetworkEventTasks < ActiveRecord::Migration[5.1]
   def change
     add_column :network_event_tasks, :date_modifier, :string
   end


### PR DESCRIPTION
With Rails 5.1, the rails version is needed to be provided in the migration. [stackoverflow ref](https://stackoverflow.com/questions/43904967/rake-db-not-working-with-paperclip-ruby-2-4-0p0-and-rails-5-1-0) 