### PR TITLE
Fix bug with select2 dropdowns not behaving correctly

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,7 +19,3 @@
 //= require bootstrap-datetimepicker
 //= require select2-full
 //= require zeroclipboard
-
-$(document).on('turbolinks:render', function() {
-  $('.select2').select2();
-});

--- a/app/assets/javascripts/select2.coffee
+++ b/app/assets/javascripts/select2.coffee
@@ -1,4 +1,4 @@
-$(document).on 'ready page:load', ->
+$(document).on 'ready page:load turbolinks:render', ->
   $('.select2').each (i, e) =>
     select = $(e)
     options =


### PR DESCRIPTION
A previous bug fix that corrected missing select2 styling
on turbolinks navigation introduced a regression on ajax-backed
select fields. The problem appears to be two document.onready callbacks
were stepping on each other. Once consolidated the select2 fields
with ajax-backed data started working correctly.

Fixes #495 

@anthonycrumley To verify, you have to navigate to /network_events after visiting some other page. If you visit /network_events directly, you won't see the bug. 