### PR TITLE
Fix duration

### DIFF
--- a/app/helpers/network_events_helper.rb
+++ b/app/helpers/network_events_helper.rb
@@ -41,8 +41,8 @@ module NetworkEventsHelper
       event_schedule_time = "Unscheduled"
     end
     
-    if event.scheduled_at.present? && event.duration.present?
-      ends_at = (event.scheduled_at + event.duration.minutes).to_formatted_s(:long)
+    if event.stop_time.present?
+      ends_at = event.stop_time.to_formatted_s(:long)
     else
       ends_at = "Unscheduled"
     end

--- a/app/helpers/network_events_helper.rb
+++ b/app/helpers/network_events_helper.rb
@@ -37,9 +37,13 @@ module NetworkEventsHelper
   def clip_event_info(event)
     if event.scheduled_at.present?
       event_schedule_time = event.try(:scheduled_at).to_formatted_s(:long)
-      ends_at = (event.scheduled_at + event.duration.minutes).to_formatted_s(:long)
     else
       event_schedule_time = "Unscheduled"
+    end
+    
+    if event.scheduled_at.present? && event.duration.present?
+      ends_at = (event.scheduled_at + event.duration.minutes).to_formatted_s(:long)
+    else
       ends_at = "Unscheduled"
     end
     

--- a/app/models/network_event.rb
+++ b/app/models/network_event.rb
@@ -120,7 +120,7 @@ class NetworkEvent < ApplicationRecord
   end
 
   def stop_time
-    if scheduled_at.present?
+    if scheduled_at.present? && duration.present?
       (scheduled_at + duration.minutes).to_time
     else
       nil

--- a/app/views/network_events/show.html.erb
+++ b/app/views/network_events/show.html.erb
@@ -90,8 +90,8 @@
   <dd><%= @network_event.scheduled_at %></dd>
 
   <dt>Ends At:</dt>
-  <dd><% if @network_event.scheduled_at.present? %>
-        <%= @network_event.scheduled_at + @network_event.duration.minutes %>
+  <dd><% if @network_event.stop_time.present? %>
+        <%= @network_event.stop_time %>
       <% end %>
   </dd>
       


### PR DESCRIPTION
When an event had an empty duration it would produce an error
because the end time was being calculated based on the start
time and duration.