### PR TITLE
Fixed error on identity missing

### DIFF
--- a/app/views/network_events/show.html.erb
+++ b/app/views/network_events/show.html.erb
@@ -208,7 +208,7 @@
         <td><%= link_to invitee.name, invitee %></td>
         <td><%= invitee.email %></td>
         <td><%= invitee.phone %></td>
-        <td><%= invitee.identity.name %></td>
+        <td><%= invitee.identity.try(:name) %></td>
       <% end %>
     </tbody>
   </table>
@@ -233,7 +233,7 @@
         <td><%= link_to participant.name, participant %></td>
         <td><%= participant.email %></td>
         <td><%= participant.phone %></td>
-        <td><%= participant.identity.name %></td>
+        <td><%= participant.identity.try(:name) %></td>
       <% end %>
     </tbody>
   </table>


### PR DESCRIPTION
When an identity was missing from a member the attendees and
participants list on the event page would get an error because
some students did not have an identity.