### PR TITLE
Add copy event functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,9 @@ gem 'coffee-rails', '~> 4.2'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
 
+# Cloning ActiveRecord models.
+gem 'deep_cloneable', '~> 2.2.2'
+
 # Pagination
 gem 'kaminari'
 # Use jquery as the JavaScript library

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,8 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     debug_inspector (0.0.2)
+    deep_cloneable (2.2.2)
+      activerecord (>= 3.1.0, < 5.2.0)
     devise (4.3.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -220,6 +222,7 @@ DEPENDENCIES
   bootstrap3-datetimepicker-rails (~> 4.17.37)
   byebug
   coffee-rails (~> 4.2)
+  deep_cloneable (~> 2.2.2)
   devise (~> 4.1)
   jbuilder (~> 2.7)
   jquery-rails

--- a/app/assets/javascripts/check_ins.coffee
+++ b/app/assets/javascripts/check_ins.coffee
@@ -4,7 +4,7 @@
 $(document).on 'ready page:load', ->
   event_id = $('#network_event_id').val()
   member_level = $('#level').val()
-  $('table :button').click ->
+  $('table.check-in-table :button').click ->
     table_row = $(this).closest("tr")
     row_member_id = $(this).siblings(".row_member_id").val()
     $.ajax({

--- a/app/assets/javascripts/network_events.coffee
+++ b/app/assets/javascripts/network_events.coffee
@@ -1,6 +1,6 @@
-$(document).on 'ready page:load', ->
-  client = new ZeroClipboard($('.copy_button'))
-  $('.copy_button').tooltip()
+$(document).on 'ready page:load turbolinks:render', ->
+  client = new ZeroClipboard($('.clip_button'))
+  $('.clip_button').tooltip()
   
   $('#transport-datetimepicker').datetimepicker({
       showClear: true,
@@ -13,14 +13,19 @@ $(document).on 'ready page:load', ->
       format: 'YYYY-MM-DD hh:mm a'
      }) 
   
-  checked = $('#network_event_needs_transport').is(':checked')
-  if checked
+  needs_transport = $('#network_event_needs_transport').val()
+  if needs_transport == 'true'
     $('#order_div').show()
   else
     $('#order_div').hide()
     
   $('#network_event_needs_transport').change ->
-    $('#order_div').slideToggle()
+    needs_transport = $('#network_event_needs_transport').val()
+    if needs_transport == 'true'
+      $('#order_div').show()
+    else
+      $('#order_div').hide()
+      
   $('#event-datetimepicker').datetimepicker({
       showClear: true,
       format: 'YYYY-MM-DD hh:mm a',

--- a/app/helpers/network_events_helper.rb
+++ b/app/helpers/network_events_helper.rb
@@ -1,5 +1,9 @@
 module NetworkEventsHelper
 
+  def copy_network_events?
+    params[:network_event_ids].present?
+  end 
+  
   def default_start_date
     if params[:start_date].present?
       params[:start_date]

--- a/app/models/network_event.rb
+++ b/app/models/network_event.rb
@@ -99,6 +99,26 @@ class NetworkEvent < ApplicationRecord
     location.try(:name)
   end
 
+  def copy(overrides={})
+    options = { 
+      except: [:notes, :transport_ordered_on, :status, :scheduled_at],
+      include: [
+        :site_contact_assignments, 
+        :school_contact_assignments,
+        :volunteer_assignments,
+        :graduating_class_assignments,
+        :organization_assignments,
+        :school_assignments,
+        :cohort_assignments,
+        :network_event_tasks
+      ] 
+    }
+    clone = self.deep_clone options
+    clone.save
+    clone.update_attributes(overrides)
+    clone
+  end
+  
   def name_with_date
     if scheduled_at.present?
       name + ' (' + scheduled_at.to_formatted_s(:long) + ')'

--- a/app/views/check_ins/new.html.erb
+++ b/app/views/check_ins/new.html.erb
@@ -5,7 +5,7 @@
 </div>
 
 <div class="table-responsive">
-  <table class="table table-striped table-bordered table-hover">
+  <table class="check-in-table table table-striped table-bordered table-hover">
     <thead>
       <tr>
         <th>First name</th>

--- a/app/views/network_events/_form.html.erb
+++ b/app/views/network_events/_form.html.erb
@@ -12,10 +12,15 @@
     </div>
   <% end %>
 
+  <% if copy_network_events? %>
+    <% params[:network_event_ids].each do |network_event_id| %>
+      <%= hidden_field_tag "network_event_ids[]", network_event_id %>
+    <% end %>
+  <% end %>
   <div class="form-group">
     <%= f.label :name, class: "col-sm-2 control-label" %>
     <div class="col-sm-10">
-      <%= f.text_field :name, class: "form-control" %>
+      <%= f.text_field :name, class: "form-control", disabled: copy_network_events? %>
     </div>
   </div>
   <% if @network_event.persisted? %>
@@ -26,7 +31,7 @@
               NetworkEvent.statuses, 
               :to_s, 
               :titleize, 
-              {}, 
+              { include_blank: true }, 
               class: "select2 form-control" %>
       </div>
     </div>
@@ -38,8 +43,9 @@
             Program.order(:name).all, 
             :id, 
             :name, 
-            {}, 
-            class: "select2 form-control" %>
+            { include_blank: true }, 
+            class: "select2 form-control",
+            data: { placeholder: 'Find Program' } %>
     </div>
   </div>
   <div class="form-group">
@@ -49,8 +55,9 @@
             Location.order(:name).all, 
             :id, 
             :name, 
-            {}, 
-            class: "select2 form-control" %>
+            { include_blank: true }, 
+            class: "select2 form-control",
+            data: { placeholder: 'Find Location' } %>
     </div>
   </div>
   <div class="form-group">
@@ -162,9 +169,13 @@
     </div>
   </div>
   <div class="form-group">
-    <%= f.label :needs_transport, 'Transportation Needed',  class: "col-sm-2 control-label" %>
+    <%= f.label :needs_transport, 'Transportation Needed', class: "col-sm-2 control-label" %>
     <div class="col-sm-10">
-      <%= f.check_box :needs_transport, class: "form-control"%>
+      <%= f.select :needs_transport, 
+            [["Yes", true], ["No", false]], 
+            { include_blank: " " }, 
+            class: "select2 form-control", 
+            data: { placeholder: 'Transportation Needed?' }  %>
     </div>
   </div>
   <div class="form-group" id='order_div'>
@@ -181,10 +192,10 @@
   <div class="form-group">
     <%= f.label :notes, class: "col-sm-2 control-label" %>
     <div class="col-sm-10">
-      <%= f.text_area :notes, class: "form-control" %>
+      <%= f.text_area :notes, class: "form-control", disabled: copy_network_events? %>
     </div>
   </div>
-  <% if @network_event.new_record?%>
+  <% if @network_event.new_record? && !copy_network_events? %>
     <div class="form-group">
       <%= f.label :network_event_tasks, "Task List", class: "col-sm-2 control-label" %>
       <div class="col-sm-10">
@@ -229,10 +240,15 @@
   <% end %>
   <div class="form-group">
     <div class="col-sm-offset-2 col-sm-10">
-      <%= f.submit event_button_name(f.object), class: "btn btn-primary" %>
-      <% if controller.action_name == 'new' %>
-        <%= f.submit "Save & Create Another", class: "btn btn-primary" %>
-      <%end%>
+      <% if copy_network_events? %>
+        <%= f.submit "Copy Event(s)", class: "btn btn-primary" %>
+        <%= f.submit "Save & Copy More", class: "btn btn-primary" %>
+      <% else %>
+        <%= f.submit event_button_name(f.object), class: "btn btn-primary" %>
+        <% if controller.action_name == 'new' %>
+          <%= f.submit "Save & Create Another", class: "btn btn-primary" %>
+        <%end%>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/network_events/index.html.erb
+++ b/app/views/network_events/index.html.erb
@@ -135,45 +135,51 @@
 <% end %>
 
 </div>
-
-<div class="table-responsive">
-  <table class="table table-striped table-bordered table-hover">
-    <thead>
-      <tr>
-        <th><%= sortable "name"%></th>
-        <th><%= sortable "status"%></th>
-        <th><%= sortable "program"%></th>
-        <th><%= sortable "location"%></th>
-        <th>Organization(s)</th>
-        <th>Volunteer(s)</th>
-        <th><%= sortable "scheduled_at", "Scheduled at"%></th>
-        <th></th>
-        <th></th>
-        <th></th>
-        <th></th>
-      </tr>
-    </thead>
-
-    <tbody>
-      <%= content_tag_for(:tr, @network_events) do |network_event| %>
-        <td><%= network_event.name %></td>
-        <td><%= network_event.status.try(:titleize) %></td>
-        <td><%= network_event.program.try(:name) %></td>
-        <td><%= network_event.location.try(:name) %></td>
-        <td><%= network_event.organizations.map(&:name).join(', ') %></td>
-        <td><%= network_event.volunteers.map(&:name).join(', ') %></td>
-        <td><%= network_event.scheduled_at.try(:to_formatted_s, :long)%></td>
-        <td><%= link_to 'Show', network_event %></td>
-        <td><%= link_to 'Edit', edit_network_event_path(network_event) %></td>
-        <td><%= link_to 'Destroy', network_event, method: :delete, data: { confirm: 'Are you sure?' } %></td>
-        <td><%= button_tag "Copy", data: {"clipboard-text" => clip_event_info(network_event), "toggle" => "tooltip", "placement" => "right"}, :title => clip_event_info(network_event), :class =>'copy_button btn btn-primary'%></td>
-      <% end %>
-    </tbody>
-  </table>
-  <%= paginate @network_events %>
+<%= form_tag(new_network_event_path, method: "get") do %>
+  <div class="table-responsive">
+    <table class="table table-striped table-bordered table-hover">
+      <thead>
+        <tr>
+          <th>Select</th>
+          <th><%= sortable "name"%></th>
+          <th><%= sortable "status"%></th>
+          <th><%= sortable "program"%></th>
+          <th><%= sortable "location"%></th>
+          <th>Organization(s)</th>
+          <th>Volunteer(s)</th>
+          <th><%= sortable "scheduled_at", "Scheduled at"%></th>
+          <th></th>
+          <th></th>
+          <th></th>
+          <th></th>
+        </tr>
+      </thead>
   
-  <%= link_to network_events_path({format: :csv}.merge(network_events_download_query_params)), class: 'btn btn-primary' do %>
-    <span class="glyphicon glyphicon-save"></span>
-    Download
-  <% end %>
-</div>
+      <tbody>
+        <%= content_tag_for(:tr, @network_events) do |network_event| %>
+          <td><%= check_box_tag "network_event_ids[]", network_event.id %></td>
+          <td><%= network_event.name %></td>
+          <td><%= network_event.status.try(:titleize) %></td>
+          <td><%= network_event.program.try(:name) %></td>
+          <td><%= network_event.location.try(:name) %></td>
+          <td><%= network_event.organizations.map(&:name).join(', ') %></td>
+          <td><%= network_event.volunteers.map(&:name).join(', ') %></td>
+          <td><%= network_event.scheduled_at.try(:to_formatted_s, :long)%></td>
+          <td><%= link_to 'Show', network_event %></td>
+          <td><%= link_to 'Edit', edit_network_event_path(network_event) %></td>
+          <td><%= link_to 'Destroy', network_event, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+          <td><%= button_tag "Clip", data: {"clipboard-text" => clip_event_info(network_event), "toggle" => "tooltip", "placement" => "right"}, :title => clip_event_info(network_event), :class =>'clip_button btn btn-primary'%></td>
+        <% end %>
+      </tbody>
+    </table>
+    <%= paginate @network_events %>
+    
+    <%= submit_tag "Copy Events", class: 'btn btn-primary' do %>
+      <span class="glyphicon glyphicon-plus"></span>
+    <% end %>
+    <%= link_to network_events_path({format: :csv}.merge(network_events_download_query_params)), class: 'btn btn-primary' do %>
+      <span class="glyphicon glyphicon-save"></span>
+      Download
+    <% end %>
+  </div>
+ <% end %> 

--- a/app/views/network_events/new.html.erb
+++ b/app/views/network_events/new.html.erb
@@ -3,7 +3,11 @@
     <span class="glyphicon glyphicon-list-alt"></span>
     Back
   <% end %>
-  <h1>New event</h1>
+  <% if copy_network_events? %>
+    <h1>Copy event(s)</h1>
+  <% else %>
+    <h1>New event</h1>
+  <% end %>
 </div>
 <% if flash[:alert] %>
   <div class="success alert-success" role="alert">

--- a/test/fixtures/network_events.yml
+++ b/test/fixtures/network_events.yml
@@ -8,6 +8,8 @@ tuggle_network:
   notes: notes_1
   status: confirmed
   user: one
+  needs_transport: false
+  transport_ordered_on: 2016-08-01 02:00:00
 
 carver_tour:
   name: Carver UAB Tour

--- a/test/fixtures/participations.yml
+++ b/test/fixtures/participations.yml
@@ -2,8 +2,8 @@
 
 attendee:
   level: attendee
-  member_id: 1
-  network_event_id: 1
+  member: jane
+  network_event: tuggle_network
   user_id: 1
 
 volunteer:

--- a/test/fixtures/volunteer_assignments.yml
+++ b/test/fixtures/volunteer_assignments.yml
@@ -1,11 +1,11 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  member_id: 1
-  network_event_id: 1
-  user_id: 1
+  member: jane
+  network_event: tuggle_network
+  user: one
 
 two:
-  member_id: 1
-  network_event_id: 1
-  user_id: 1
+  member: john
+  network_event: tuggle_network
+  user: one

--- a/test/models/network_event_test.rb
+++ b/test/models/network_event_test.rb
@@ -28,4 +28,239 @@ class NetworkEventTest < ActiveSupport::TestCase
     refute_includes network_event.invitees, members(:two)
   end
   
+  test "When a network event is copied the id should be present" do
+    original = network_events(:tuggle_network)
+    copy = original.copy
+    assert copy.id.present?
+  end
+  
+  test "When a network event is copied the id should be different" do
+    original = network_events(:tuggle_network)
+    copy = original.copy
+    refute_equal original.id, copy.id
+  end
+  
+  test "When a network event is copied the name should be the same" do
+    original = network_events(:tuggle_network)
+    assert_guard original.name.present?, 
+      "Network event fixture expected to have a name"
+      
+    copy = original.copy
+    assert_equal original.name, copy.name
+  end
+  
+  test "When a network event is copied, scheduled at should be the empty" do
+    original = network_events(:tuggle_network)
+    assert_guard original.scheduled_at.present?, 
+      "Network event fixture expected to have a scheduled at date/time"
+      
+    copy = original.copy
+    assert_nil copy.scheduled_at
+  end
+  
+  test "When a network event is copied the created at date should be different" do
+    original = network_events(:tuggle_network)
+    assert_guard original.created_at.present?, 
+      "Network event fixture expected to have a created at date/time"
+      
+    copy = original.copy
+    refute_equal original.created_at, copy.created_at
+  end
+  
+  test "When a network event is copied the created at date should be present" do
+    original = network_events(:tuggle_network)
+    copy = original.copy
+    refute_nil copy.created_at
+  end
+  
+  test "When a network event is copied the updated at date should be different" do
+    original = network_events(:tuggle_network)
+    assert_guard original.updated_at.present?, 
+      "Network event fixture expected to have a updated at date/time"
+      
+    copy = original.copy
+    refute_equal original.updated_at, copy.updated_at
+  end
+  
+  test "When a network event is copied the updated at date should be present" do
+    original = network_events(:tuggle_network)
+    copy = original.copy
+    refute_nil copy.updated_at
+  end
+  
+  test "When a network event is copied the duration should be the same" do
+    original = network_events(:tuggle_network)
+    assert_guard original.duration.present?, 
+      "Network event fixture expected to have a duration"
+      
+    copy = original.copy
+    assert_equal original.duration, copy.duration
+  end
+  
+  test "When a network event is copied, needs transportation should be the same" do
+    original = network_events(:tuggle_network)
+    assert_guard !original.needs_transport.nil?, 
+      "Network event fixture expected to have a needs transportation"
+      
+    copy = original.copy
+    assert_equal original.needs_transport, copy.needs_transport
+  end
+  
+  test "When a network event is copied the transport ordered on date should be empty" do
+    original = network_events(:tuggle_network)
+    assert_guard original.transport_ordered_on.present?, 
+      "Network event fixture expected to have a transport ordered on date"
+      
+    copy = original.copy
+    assert_nil copy.transport_ordered_on
+  end
+  
+  test "When a network event is copied the notes should be empty" do
+    original = network_events(:tuggle_network)
+    assert_guard original.notes.present?, 
+      "Network event fixture expected to have notes"
+      
+    copy = original.copy
+    assert_nil copy.notes
+  end
+  
+  test "When a network event is copied the status should be empty" do
+    original = network_events(:tuggle_network)
+    assert_guard original.status.present?, 
+      "Network event fixture expected to have status"
+      
+    copy = original.copy
+    assert_nil copy.status
+  end
+  
+  test "When a network event is copied the program should be the same" do
+    original = network_events(:tuggle_network)
+    assert_guard original.program.present?, 
+      "Network event fixture expected to have a program"
+      
+    copy = original.copy
+    assert_equal original.program, copy.program
+  end
+  
+  test "When a network event is copied the location should be the same" do
+    original = network_events(:tuggle_network)
+    assert_guard original.location.present?, 
+      "Network event fixture expected to have a location"
+      
+    copy = original.copy
+    assert_equal original.location, copy.location
+  end
+  
+  test "When a network event is copied the user should be the same" do
+    original = network_events(:tuggle_network)
+    assert_guard original.user.present?, 
+      "Network event fixture expected to have a user"
+      
+    copy = original.copy
+    assert_equal original.user, copy.user
+  end
+  
+  test "When a network event is copied the site contacts should be the same" do
+    original = network_events(:tuggle_network)
+    assert_guard original.site_contacts.present?, 
+      "Network event fixture expected to have site contacts"
+      
+    copy = original.copy
+    assert_equal original.site_contacts, copy.site_contacts
+  end
+  
+  test "When a network event is copied the school contacts should be the same" do
+    original = network_events(:tuggle_network)
+    assert_guard original.school_contacts.present?, 
+      "Network event fixture expected to have school contacts"
+      
+    copy = original.copy
+    assert_equal original.school_contacts, copy.school_contacts
+  end
+  
+  test "When a network event is copied the volunteers should be the same" do
+    original = network_events(:tuggle_network)
+    assert_guard original.volunteers.present?, 
+      "Network event fixture expected to have volunteers"
+      
+    copy = original.copy
+    assert_equal original.volunteers, copy.volunteers
+  end
+  
+  test "When a network event is copied the graduating classes should be the same" do
+    original = network_events(:tuggle_network)
+    assert_guard original.graduating_classes.present?, 
+      "Network event fixture expected to have graduating classes"
+      
+    copy = original.copy
+    assert_equal original.graduating_classes, copy.graduating_classes
+  end
+  
+  test "When a network event is copied the organizations should be the same" do
+    original = network_events(:tuggle_network)
+    assert_guard original.organizations.present?, 
+      "Network event fixture expected to have organizations"
+      
+    copy = original.copy
+    assert_equal original.organizations, copy.organizations
+  end
+  
+  test "When a network event is copied the schools should be the same" do
+    original = network_events(:tuggle_network)
+    assert_guard original.schools.present?, 
+      "Network event fixture expected to have schools"
+      
+    copy = original.copy
+    assert_equal original.schools, copy.schools
+  end
+  
+  test "When a network event is copied the cohorts should be the same" do
+    original = network_events(:tuggle_network)
+    assert_guard original.cohorts.present?, 
+      "Network event fixture expected to have cohorts"
+      
+    copy = original.copy
+    assert_equal original.cohorts, copy.cohorts
+  end
+  
+  test "When a network event is copied the participants should not be copied" do
+    original = network_events(:tuggle_network)
+    assert_guard original.participants.present?, 
+      "Network event fixture expected to have participants"
+      
+    copy = original.copy
+    assert_empty copy.participants
+  end
+  
+  test "When a network event is copied the tasks should be the same" do
+    original = network_events(:tuggle_network)
+    assert_guard original.network_event_tasks.present?, 
+      "Network event fixture expected to have tasks"
+      
+    copy = original.copy
+    assert_equal original.network_event_tasks.count, copy.network_event_tasks.count
+  end
+  
+  test "When a network event is copied the cohorts can be overridden" do
+    original = network_events(:tuggle_network)
+    assert_guard original.cohorts.present?, 
+      "Network event fixture expected to have cohorts"
+    assert_guard original.cohorts.exclude?(cohorts(:red)), 
+      "Network event fixture cohorts expected to not include red"
+      
+    overrides = { cohort_ids: [cohorts(:red).id, cohorts(:purple).id]}
+    copy = original.copy(overrides)
+    assert_equal Cohort.where(id: overrides[:cohort_ids]), copy.cohorts
+  end
+  
+  test "When a network event is copied the cohorts can be removed" do
+    original = network_events(:tuggle_network)
+    assert_guard original.cohorts.present?, 
+      "Network event fixture expected to have cohorts"
+      
+    overrides = { cohort_ids: []}
+    copy = original.copy(overrides)
+    assert_equal Cohort.where(id: overrides[:cohort_ids]), copy.cohorts
+  end
+  
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,4 +12,25 @@ class ActiveSupport::TestCase
     File.read(Rails.root.to_s + "/test/support/files/#{name}")
   end 
   
+  # Implementation of the Guard Assertion unit testing pattern.  This should
+  # be used to assert that preconditions of external dependancies are valid
+  # before executing the test.  Dependencies external to the test are things
+  # like fixtures or mocks.  The test depends on how they act but does not
+  # create them so their behavior may change unexpectedly over time.
+  #
+  # Note: The name is assert_guard rather than guard_assert so that the test
+  #       framework will know what line to show for the test failure since it
+  #       following the naming convention assert_*.
+  # 
+  # Reference: http://xunitpatterns.com/Guard%20Assertion.html
+  #
+  # Example:
+  # 
+  #   assert_guard network_events(:tuggle_network).program.present?,
+  #     "Network event fixture expected to have a program"
+  # 
+  def assert_guard(condition, message)
+    assert condition, "Assert Guard: #{message}"
+  end
+  
 end


### PR DESCRIPTION
This is the initial version of copying events.  Multiple events can be
selected from the event listing page and copied.  A screen will be diplayed
that will allow any of the attributes of the originals to be overidden
in the copies.