### PR TITLE
Fix the clip button for events

### DIFF
--- a/app/views/network_events/index.html.erb
+++ b/app/views/network_events/index.html.erb
@@ -168,7 +168,7 @@
           <td><%= link_to 'Show', network_event %></td>
           <td><%= link_to 'Edit', edit_network_event_path(network_event) %></td>
           <td><%= link_to 'Destroy', network_event, method: :delete, data: { confirm: 'Are you sure?' } %></td>
-          <td><%= button_tag "Clip", data: {"clipboard-text" => clip_event_info(network_event), "toggle" => "tooltip", "placement" => "right"}, :title => clip_event_info(network_event), :class =>'clip_button btn btn-primary'%></td>
+          <td><%= button_tag "Clip", type: 'button', data: {"clipboard-text" => clip_event_info(network_event), "toggle" => "tooltip", "placement" => "right"}, :title => clip_event_info(network_event), :class =>'clip_button btn btn-primary'%></td>
         <% end %>
       </tbody>
     </table>


### PR DESCRIPTION
The clip button was previously not in a form.  When the copy event
functionality was added the event list table was put in a form.
This made the clip button submit the form since it was a submit type
of button.  The button is not a button type of button and it no longer
submits the form when clicked.