### PR TITLE
Fix and simplify new task button on event show page

### DIFF
--- a/app/assets/javascripts/network_events.coffee
+++ b/app/assets/javascripts/network_events.coffee
@@ -38,9 +38,7 @@ $(document).on 'ready page:load', ->
   $("#new-task-form").hide()
   $("#create-task-button").on "click", ->
     $("#new-task-form").show()
-    $("#create-task-button").html("Hide Form")
-    $("#create-task-button").on "click", ->
-      $("#new-task-form").hide()
+    $("#create-task-button").hide()
       
     
   # Task completion on event show page


### PR DESCRIPTION
I removed the "hide form" button toggle due to it being unneeded and functioning improperly.