### PR TITLE
Specify timezone in test runs

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 ENV['RAILS_ENV'] ||= 'test'
+ENV['TZ'] = 'UTC'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 


### PR DESCRIPTION
Specify timezone in test runs, as tests and app expect the timezone in use to be 'UTC'

Fixes #529.