### PR TITLE
Add needed options  to task date modifiers

### DIFF
--- a/app/models/common_task.rb
+++ b/app/models/common_task.rb
@@ -4,17 +4,19 @@ class CommonTask < ApplicationRecord
   
   def self.date_modifiers 
     [
-       "Monday before event",
-       "2 Mondays before event",
-       "Friday before event",
-       "2 Fridays before event",
-       "1 week before event",
-       "2 weeks before event",
-       "3 weeks before event",
-       "1 month before event",
-       "2 months before event",
-       "3 months before event",
-       "4 months before event"
+      "Day before event",
+      "1 week after event",
+      "Monday before event",
+      "2 Mondays before event",
+      "Friday before event",
+      "2 Fridays before event",
+      "1 week before event",
+      "2 weeks before event",
+      "3 weeks before event",
+      "1 month before event",
+      "2 months before event",
+      "3 months before event",
+      "4 months before event"
     ]
   end
 end

--- a/app/models/network_event.rb
+++ b/app/models/network_event.rb
@@ -155,6 +155,10 @@ class NetworkEvent < ApplicationRecord
     self.network_event_tasks.each do |task|
       scheduled_at = self.scheduled_at.in_time_zone("Central Time (US & Canada)")
       case task.date_modifier
+      when 'Day before event'
+        task.due_date = scheduled_at.end_of_day - 1.day
+      when '1 week after event'
+        task.due_date = scheduled_at.end_of_day + 1.week
       when 'Monday before event'
         task.due_date = scheduled_at.end_of_week(:tuesday) - 1.week
       when '2 Mondays before event'


### PR DESCRIPTION
Two options were added to the date modifiers when creating common/event
tasks. "Day before" and "1 week after"