### PR TITLE
Add ability to select no owner when creating tasks

### DIFF
--- a/app/models/network_event_task.rb
+++ b/app/models/network_event_task.rb
@@ -34,7 +34,9 @@ class NetworkEventTask < ApplicationRecord
   
   def as_json(options)
     result = super
-    result["completed_at"] = completed_at.in_time_zone("Central Time (US & Canada)").strftime(' %a, %B %e %Y')
+    if completed_at?
+      result["completed_at"] = completed_at.in_time_zone("Central Time (US & Canada)").strftime(' %a, %B %e %Y')
+    end
     result
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,9 @@ class User < ApplicationRecord
   has_many :created_organizations, class_name: "Organization", foreign_key: :created_by_id
   has_many :common_tasks
   has_many :network_event_tasks
+  
+  def self.best_in_place_options
+    options = User.all.map {|u| [u.id, u.email]} 
+    options = [[nil, '']] + options
+  end
 end

--- a/app/views/common_tasks/_form.html.erb
+++ b/app/views/common_tasks/_form.html.erb
@@ -25,7 +25,7 @@
             User.order(:email).all,
             :id,
             :email,
-            {},
+            { :include_blank => "No owner selected" },
             class: "select2 form-control" %>
       </div>
   </div>

--- a/app/views/common_tasks/index.html.erb
+++ b/app/views/common_tasks/index.html.erb
@@ -13,7 +13,6 @@
             <th>Name</th>
             <th>Owner</th>
             <th>Default due date</th>
-            <th>User</th>
             <th></th>
         <th></th>
         <th></th>
@@ -25,7 +24,6 @@
             <td><%= common_task.name %></td>
             <td><%= common_task.owner.try(:email) %></td>
             <td><%= common_task.try(:date_modifier) %></td>
-            <td><%= common_task.user.try(:email) %></td>
             <td><%= link_to 'Show', common_task %></td>
         <td><%= link_to 'Edit', edit_common_task_path(common_task) %></td>
         <td><%= link_to 'Destroy', common_task, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/network_event_tasks/index.html.erb
+++ b/app/views/network_event_tasks/index.html.erb
@@ -107,7 +107,7 @@
         <td><%= best_in_place task, :name, :as => :input %></td>
         <td><%= link_to(task.network_event.name, network_event_path(task.network_event)) if task.network_event %></td>
         <td><%= best_in_place task, :owner_id, :as => :select, 
-                :collection => User.all.map { |u| [u.id, u.email] } %></td>
+                :collection => User.best_in_place_options %></td>
         <td><%= task.formatted_due_date if task.due_date %></td>
         <td><%= task.common_task.try(:name) %></td>
         <td class="completed_at"><%= task.formatted_completed_at %></td>

--- a/app/views/network_events/_form.html.erb
+++ b/app/views/network_events/_form.html.erb
@@ -227,7 +227,7 @@
                       data: {placeholder: 'Select Date Modifier'} %>
             </div>
             <div class="col-md-3">
-              <%= event_task.collection_select :owner_id, User.all, :id, :email, {}, class: "select2 form-control task-field", disabled: true %>
+              <%= event_task.collection_select :owner_id, User.all, :id, :email, {:include_blank => "No owner selected"}, class: "select2 form-control task-field", disabled: true %>
             </div>
               <%= event_task.hidden_field :common_task_id , disabled: true, class: "task-field" %>
             <div class="col-sm-1">

--- a/app/views/network_events/show.html.erb
+++ b/app/views/network_events/show.html.erb
@@ -149,7 +149,7 @@
           <td class="task_due_date"><%= task.formatted_due_date %> </td>
           <td class="task_completed_at"><%= task.formatted_completed_at %> </td>
           <td class="task_owner"><%= best_in_place task, :owner_id, :as => :select, 
-                                    :collection => User.all.map { |u| [u.id, u.email]} %></td>
+                                    :collection => User.best_in_place_options %></td>
           <td class="task_mark">
             <% if not task.completed_at.present? %>
               <%= button_to("Mark Completed", network_event_task_path(task) , remote: true, method: :patch, name: "task_button", class:"btn btn-primary task_button",
@@ -175,7 +175,7 @@
       </div>
       <div class="form-group">
         <%= f.label :owner %>
-          <%= f.collection_select :owner_id, User.all, :id, :email, {}, class: "select2 form-control"%>
+          <%= f.collection_select :owner_id, User.all, :id, :email, {:include_blank => "No owner selected"}, class: "select2 form-control"%>
       </div>
       <div class="form-group">
         <%= f.label :common_task %>


### PR DESCRIPTION
Users can now create tasks without owners. Inline editing on the event
task list and task index page also allow tasks to be updated with
no owners.