### PR TITLE
Added info to event dropdowns

### DIFF
--- a/app/models/network_event.rb
+++ b/app/models/network_event.rb
@@ -121,9 +121,9 @@ class NetworkEvent < ApplicationRecord
   
   def name_with_date
     if scheduled_at.present?
-      name + ' (' + scheduled_at.to_formatted_s(:long) + ')'
+      name + ' (' + scheduled_at.to_formatted_s(:long) + ', ' + location.name + ')'
     else
-      name
+      name + ' (at ' + location.name + ')'
     end
   end
 

--- a/app/views/network_event_tasks/index.html.erb
+++ b/app/views/network_event_tasks/index.html.erb
@@ -42,7 +42,7 @@
               options_from_collection_for_select(
                 NetworkEvent.order(:name).all, 
                 :id, 
-                :name,
+                :name_with_date,
                 params[:network_event_ids]
               ),
               class: "select2 form-control", 


### PR DESCRIPTION
I added info to the event dropdown on the task index page
to include the date and location of the event to make it easier
for users to identify the correct event.