### PR TITLE
Event export does not include all the events

### DIFF
--- a/app/controllers/network_events_controller.rb
+++ b/app/controllers/network_events_controller.rb
@@ -6,8 +6,12 @@ class NetworkEventsController < ApplicationController
   # GET /network_events.json
   # GET /network_events.csv
   def index
-    @network_events = filtered_events.page params[:page]
+    @network_events = filtered_events
     @unscheduled_only = params[:unscheduled_events_only]
+    respond_to do |format|
+      format.any(:html, :json) { @network_events = @network_events.page params[:page] }
+      format.csv
+    end
   end
 
   # GET /network_events/1

--- a/test/controllers/network_events_controller_test.rb
+++ b/test/controllers/network_events_controller_test.rb
@@ -8,6 +8,18 @@ class NetworkEventsControllerTest < ActionController::TestCase
     sign_in users(:one)
   end
 
+  test "should get json with pagination" do
+    get :index, params: { :format => :json }
+    assert_pagination assigns(:network_events),
+      "Events json should be paginated."
+  end
+  
+  test "should get index with pagination" do
+    get :index
+    assert_pagination assigns(:network_events),
+      "Events listing should be paginated."
+  end
+  
   test "should get index with default filter" do
     get :index
     assert_response :success
@@ -117,6 +129,16 @@ class NetworkEventsControllerTest < ActionController::TestCase
     assert_response :success
 
     assert_equal file_data('network_events.csv'), response.body
+  end
+  
+  test "should get csv without pagination" do
+    time = Time.local(2016, 8, 1, 10, 5, 0)
+    Timecop.travel(time) do
+      get :index, params: { :format => :csv }
+    end
+    
+    refute_pagination assigns(:network_events),
+      "Events csv export should not be paginated."
   end
 
   test "should get edit" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,4 +34,31 @@ class ActiveSupport::TestCase
     assert condition, "Assert Guard: #{message}"
   end
   
+  # Assertion that ensures a collection or ActiveRecord scopish object has 
+  # pagination.  A direct way of testing could not be found so an indirect
+  # test is used that checks for a pagination specific method existing.
+  #
+  # Example:
+  # 
+  #   assert_pagination assigns(:network_events), 
+  #     "Network events should be listed with pagination."
+  #
+  def assert_pagination(collection, message='')
+    assert collection.respond_to?(:total_pages), message
+  end
+  
+  # Refutation that ensures a collection or ActiveRecord scopish object does 
+  # not have pagination.  A direct way of testing could not be found so an 
+  # indirect test is used that checks for a pagination specific method 
+  # not existing on the collection.
+  #
+  # Example:
+  # 
+  #   refute_pagination assigns(:network_events), 
+  #     "Network events should be exported without pagination."
+  #
+  def refute_pagination(collection, message='')
+    refute collection.respond_to?(:total_pages), message
+  end
+  
 end


### PR DESCRIPTION
The event csv export was including pagination when it should export
all the events that match the current search criteria.  To resolve
the problem, pagination was removed from the csv export for events.