### PR TITLE
Added the ability to quickly add members to cohorts

### DIFF
--- a/app/controllers/cohortians_controller.rb
+++ b/app/controllers/cohortians_controller.rb
@@ -1,0 +1,21 @@
+class CohortiansController < ApplicationController
+  before_action :set_cohort, only: [:create, :destroy]
+
+  # POST /cohorts
+  # POST /cohorts.json
+  def create
+    params[:member_ids].each do |member_id|
+      Cohortian.where(cohort: @cohort, member_id: member_id).first_or_create
+    end
+
+    redirect_to @cohort
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_cohort
+    @cohort = Cohort.find(params[:cohort_id])
+  end
+
+end

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -77,6 +77,11 @@ class MembersController < ApplicationController
         where(identities: {id: params[:identity_ids]})
       end
 
+      # Include cohorts to prevent n+1
+      if params[:include] == 'cohorts'
+        members = members.includes(:cohorts)
+      end
+
       # limit the size of xml_http_request? responses
       if request.xhr?
         members = members.limit(25)

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,6 +1,6 @@
 class Member < ApplicationRecord
   default_scope { order(:last_name, :first_name) }
-  
+
   include PgSearch
 
   pg_search_scope :search_by_full_name,

--- a/app/views/cohorts/show.html.erb
+++ b/app/views/cohorts/show.html.erb
@@ -18,3 +18,45 @@
   <dd><%= @cohort.user.try(:email) %></dd>
 
 </dl>
+
+<h2>Members</h2>
+
+<%= form_tag(cohortians_path) do %>
+  <%= hidden_field_tag :cohort_id, @cohort.id %>
+  <div class="container">
+    <div class="input-group">
+        <span class="input-group-btn">
+          <button class="btn btn-default" type="submit" name="commit">Add Members</button>
+        </span>
+        <%= select_tag :member_ids,
+              [],
+              class: "select2 ajax form-control",
+              multiple: true,
+              data: { ajax: { url: members_path(include: 'cohorts') }, placeholder: 'Find members to add' }  %>
+    </div>
+  </div>
+<% end %>
+
+<hr>
+
+<div class="table-responsive">
+  <table class="table table-striped table-bordered table-hover">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Email</th>
+        <th>Phone</th>
+        <th>Identity</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <%= content_tag_for(:tr, @cohort.cohortians.joins(:member).includes(:member).merge(Member.order(:last_name, :first_name))) do |cohortian| %>
+        <td><%= link_to cohortian.member.name, cohortian.member %></td>
+        <td><%= cohortian.member.email %></td>
+        <td><%= cohortian.member.phone %></td>
+        <td><%= cohortian.member.identity.try(:name) %></td>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/members/index.json.jbuilder
+++ b/app/views/members/index.json.jbuilder
@@ -1,4 +1,9 @@
 json.array!(@members) do |member|
-  json.extract! member, :id, :text, :first_name, :last_name, :phone, :email, :identity_id, :school_id, :graduating_class_id
+  json.extract! member, :id, :first_name, :last_name, :phone, :email, :identity_id, :school_id, :graduating_class_id
+  if params[:include] == 'cohorts' && member.cohorts.present?
+    json.text member.text + " (#{member.cohorts.map(&:name).join(', ')})"
+  else
+    json.text member.text
+  end
   json.url member_url(member, format: :json)
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   resources :talents
   resources :schools
   resources :cohorts
+  resources :cohortians, only: [:create, :destroy]
   resources :graduating_classes
   resources :network_actions
   resources :programs

--- a/test/controllers/cohortians_controller_test.rb
+++ b/test/controllers/cohortians_controller_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+class CohortiansControllerTest < ActionController::TestCase
+  include Devise::Test::ControllerHelpers
+
+  setup do
+    sign_in users(:one)
+  end
+
+  test "should create cohortian" do
+    assert_difference('Cohortian.count') do
+      post :create, params: {
+        cohort_id: cohorts(:red).id,
+        member_ids: [members(:martin).id]
+      }
+    end
+  end
+
+  test "should not create a duplicate cohortian" do
+    assert_guard Cohortian.
+      where(cohort: cohorts(:purple), member: members(:martin)).
+      exists?,
+      "Martin must be in the purple cohort"
+
+    assert_no_difference('Cohortian.count') do
+      post :create, params: {
+        cohort_id: cohorts(:purple).id,
+        member_ids: [members(:martin).id]
+      }
+    end
+
+  end
+
+
+  test "should go back to cohort page after creating cohortians" do
+    post :create, params: {
+      cohort_id: cohorts(:red).id,
+      member_ids: [members(:martin).id]
+    }
+
+    assert_redirected_to cohort_path(cohorts(:red))
+  end
+
+end

--- a/test/controllers/cohorts_controller_test.rb
+++ b/test/controllers/cohorts_controller_test.rb
@@ -32,6 +32,28 @@ class CohortsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "should show cohort's cohortians" do
+    get :show, params: { id: cohorts(:green) }
+    assert_select 'td', 'Rosa Parks'
+  end
+
+  test "should not show cohortians from other cohorts" do
+    get :show, params: { id: cohorts(:green) }
+    assert_select 'td', text: 'Martin King', count: 0
+  end
+
+  test "should have cohort id hidden field" do
+    get :show, params: { id: cohorts(:green) }
+    assert_select "form input[name=cohort_id][type=hidden]" do
+      assert_select "[value=?]", cohorts(:green).id.to_s
+    end
+  end
+
+  test "should have member multi-select" do
+    get :show, params: { id: cohorts(:green) }
+    assert_select "form select[name='member_ids[]']"
+  end
+
   test "should get edit" do
     get :edit, params: { id: @cohort }
     assert_response :success

--- a/test/fixtures/cohortians.yml
+++ b/test/fixtures/cohortians.yml
@@ -1,9 +1,9 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  member_id: 1
-  cohort_id: 1
+  member: martin
+  cohort: purple
 
 two:
-  member_id: 1
-  cohort_id: 1
+  member: rosa
+  cohort: green


### PR DESCRIPTION
Added a quick search for members with a add button to quickly add
members to a cohort.  Also added a table of members to the cohort
show page to be able to see the members currently in the cohort.

Added an "include" parameter to the member index json so that cohorts
can be added to a member search response to be able differntiate
duplicates.