### PR TITLE
Fixed broken member edit page

### DIFF
--- a/app/views/members/edit.html.erb
+++ b/app/views/members/edit.html.erb
@@ -10,5 +10,11 @@
   <h1>Editing member</h1>
 </div>
 
-<%= render 'form' %>
-
+<%= form_for(@member, html: { class: "form-horizontal", role: "form" }) do |f| %>
+  <%= render partial: "form", locals: {f: f} %>
+  <div class="form-group">
+    <div class="col-sm-offset-2 col-sm-10">
+      <%= f.submit class: "btn btn-primary" %>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
The form tag was removed from the _form partial and moved to the
new and new_in_group views.  It was not added to the edit view so
the test failed for the edit view.  Fixed the problem by adding the
form tag to the edit view.