### PR TITLE
Add user permissions for resource deletion

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,8 @@ gem 'bootstrap3-datetimepicker-rails', '~> 4.17.37'
 # gem for in-place editing
 gem 'bootstrap-editable-rails'
 
+gem 'cancancan', '~> 2.0'
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
       momentjs-rails (>= 2.8.1)
     builder (3.2.3)
     byebug (9.0.5)
+    cancancan (2.0.0)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -229,6 +230,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.3.6)
   bootstrap3-datetimepicker-rails (~> 4.17.37)
   byebug
+  cancancan (~> 2.0)
   coffee-rails (~> 4.2)
   deep_cloneable (~> 2.2.2)
   devise (~> 4.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,12 +4,12 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   
   before_action :authenticate_user!
-  before_action :require_admin_user!
+  before_action :require_admin_or_staff_user!
   
   protected
   
-  def require_admin_user!
-    unless current_user.admin?
+  def require_admin_or_staff_user!
+    unless current_user.admin? or current_user.staff?
       redirect_to root_path
     end
   end

--- a/app/controllers/cohorts_controller.rb
+++ b/app/controllers/cohorts_controller.rb
@@ -1,5 +1,6 @@
 class CohortsController < ApplicationController
   before_action :set_cohort, only: [:show, :edit, :update, :destroy]
+  load_and_authorize_resource
 
   # GET /cohorts
   # GET /cohorts.json

--- a/app/controllers/communications_controller.rb
+++ b/app/controllers/communications_controller.rb
@@ -1,6 +1,7 @@
 class CommunicationsController < ApplicationController
   before_action :set_member, only: [:new, :show, :edit, :update, :destroy]
   before_action :set_communication, only: [:show, :edit, :update, :destroy]
+  load_and_authorize_resource
 
   # GET members/1/communications/1
   # GET members/1/communications/1.json

--- a/app/controllers/extracurricular_activities_controller.rb
+++ b/app/controllers/extracurricular_activities_controller.rb
@@ -1,5 +1,6 @@
 class ExtracurricularActivitiesController < ApplicationController
   before_action :set_extracurricular_activity, only: [:show, :edit, :update, :destroy]
+  load_and_authorize_resource
 
   # GET /extracurricular_activities
   # GET /extracurricular_activities.json

--- a/app/controllers/graduating_classes_controller.rb
+++ b/app/controllers/graduating_classes_controller.rb
@@ -1,5 +1,6 @@
 class GraduatingClassesController < ApplicationController
   before_action :set_graduating_class, only: [:show, :edit, :update, :destroy]
+  load_and_authorize_resource
 
   # GET /graduating_classes
   # GET /graduating_classes.json

--- a/app/controllers/identities_controller.rb
+++ b/app/controllers/identities_controller.rb
@@ -1,5 +1,6 @@
 class IdentitiesController < ApplicationController
   before_action :set_identity, only: [:show, :edit, :update, :destroy]
+  load_and_authorize_resource
 
   # GET /identities
   # GET /identities.json

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -1,5 +1,6 @@
 class LocationsController < ApplicationController
   before_action :set_location, only: [:show, :edit, :update, :destroy]
+  load_and_authorize_resource
 
 
   # GET /locations

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -1,5 +1,6 @@
 class MembersController < ApplicationController
   before_action :set_member, only: [:show, :edit, :update, :destroy]
+  load_and_authorize_resource
 
   # GET /members
   # GET /members.json

--- a/app/controllers/neighborhoods_controller.rb
+++ b/app/controllers/neighborhoods_controller.rb
@@ -1,5 +1,6 @@
 class NeighborhoodsController < ApplicationController
   before_action :set_neighborhood, only: [:show, :edit, :update, :destroy]
+  load_and_authorize_resource
 
   # GET /neighborhoods
   # GET /neighborhoods.json

--- a/app/controllers/network_actions_controller.rb
+++ b/app/controllers/network_actions_controller.rb
@@ -1,5 +1,6 @@
 class NetworkActionsController < ApplicationController
   before_action :set_network_action, only: [:show, :edit, :update, :destroy]
+  load_and_authorize_resource
 
   # GET /network_actions
   # GET /network_actions.json

--- a/app/controllers/network_event_tasks_controller.rb
+++ b/app/controllers/network_event_tasks_controller.rb
@@ -1,4 +1,5 @@
 class NetworkEventTasksController < ApplicationController
+  load_and_authorize_resource
   
   def create
     @network_event_task = NetworkEventTask.new(network_event_task_params)

--- a/app/controllers/network_events_controller.rb
+++ b/app/controllers/network_events_controller.rb
@@ -1,6 +1,7 @@
 class NetworkEventsController < ApplicationController
   before_action :set_network_event, only: [:show, :edit, :update, :destroy]
   helper_method :sort_column, :sort_direction
+  load_and_authorize_resource
 
   # GET /network_events
   # GET /network_events.json

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,5 +1,6 @@
 class OrganizationsController < ApplicationController
   before_action :set_organization, only: [:show, :edit, :update, :destroy]
+  load_and_authorize_resource
 
 
   # GET /organizations

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -1,5 +1,6 @@
 class ProgramsController < ApplicationController
   before_action :set_program, only: [:show, :edit, :update, :destroy]
+  load_and_authorize_resource
 
   # GET /programs
   # GET /programs.json

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -1,5 +1,6 @@
 class SchoolsController < ApplicationController
   before_action :set_school, only: [:show, :edit, :update, :destroy]
+  load_and_authorize_resource
 
   # GET /schools
   # GET /schools.json

--- a/app/controllers/talents_controller.rb
+++ b/app/controllers/talents_controller.rb
@@ -1,5 +1,6 @@
 class TalentsController < ApplicationController
   before_action :set_talent, only: [:show, :edit, :update, :destroy]
+  load_and_authorize_resource
 
   # GET /talents
   # GET /talents.json

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,5 +1,6 @@
 class Users::ConfirmationsController < Devise::ConfirmationsController
-  skip_before_action :require_admin_user!
+  skip_before_action :require_admin_or_staff_user!
+  
   
   # GET /resource/confirmation/new
   # def new

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,6 +1,6 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  skip_before_action :require_admin_user!
-  
+  skip_before_action :require_admin_or_staff_user!
+
   # You should configure your model like this:
   # devise :omniauthable, omniauth_providers: [:twitter]
 

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,6 +1,6 @@
 class Users::PasswordsController < Devise::PasswordsController
-  skip_before_action :require_admin_user!
-  
+  skip_before_action :require_admin_or_staff_user!
+
   # GET /resource/password/new
   # def new
   #   super

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,6 +1,6 @@
 class Users::RegistrationsController < Devise::RegistrationsController
-  skip_before_action :require_admin_user!
-  
+  skip_before_action :require_admin_or_staff_user!
+
 # before_action :configure_sign_up_params, only: [:create]
 # before_action :configure_account_update_params, only: [:update]
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,6 +1,6 @@
 class Users::SessionsController < Devise::SessionsController
-  skip_before_action :require_admin_user!
-  
+  skip_before_action :require_admin_or_staff_user!
+
 # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,5 +1,5 @@
 class Users::UnlocksController < Devise::UnlocksController
-  skip_before_action :require_admin_user!
+  skip_before_action :require_admin_or_staff_user!
   
   # GET /resource/unlock/new
   # def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update, :destroy]
+  load_and_authorize_resource
 
   # GET /users
   # GET /users.json
@@ -48,6 +49,6 @@ class UsersController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def user_params
-      params.require(:user).permit(:admin)
+      params.require(:user).permit(:admin, :staff)
     end
 end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,5 +1,5 @@
 class WelcomeController < ApplicationController
-  skip_before_action :require_admin_user!
+  skip_before_action :require_admin_or_staff_user!
   
   def index
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,40 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    # Define abilities for the passed in user here. For example:
+    #
+    #   user ||= User.new # guest user (not logged in)
+    #   if user.admin?
+    #     can :manage, :all
+    #   else
+    #     can :read, :all
+    #   end
+    #
+    # The first argument to `can` is the action you are giving the user
+    # permission to do.
+    # If you pass :manage it will apply to every action. Other common actions
+    # here are :read, :create, :update and :destroy.
+    #
+    # The second argument is the resource the user can perform the action on.
+    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
+    # class of the resource.
+    #
+    # The third argument is an optional hash of conditions to further filter the
+    # objects.
+    # For example, here the user can only update published articles.
+    #
+    #   can :update, Article, :published => true
+    #
+    # See the wiki for details:
+    # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
+    user ||= User.new
+    if user.admin?
+      can :manage, :all
+    end
+    
+    if user.staff?
+      can [:create, :read, :update], :all
+    end
+  end
+end

--- a/app/views/cohorts/index.html.erb
+++ b/app/views/cohorts/index.html.erb
@@ -14,7 +14,9 @@
         <th>Status</th>
         <th></th>
         <th></th>
-        <th></th>
+        <% if can? :delete, Cohort %>
+          <th></th>
+        <% end %>
       </tr>
     </thead>
 
@@ -24,7 +26,9 @@
         <td><%= cohort.active ? 'Active' : 'Deactive' %></td>
         <td><%= link_to 'Show', cohort %></td>
         <td><%= link_to 'Edit', edit_cohort_path(cohort) %></td>
-        <td><%= link_to 'Destroy', cohort, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% if can? :delete, Cohort %>
+          <td><%= link_to 'Destroy', cohort, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% end %>
       <% end %>
     </tbody>
   </table>

--- a/app/views/common_tasks/index.html.erb
+++ b/app/views/common_tasks/index.html.erb
@@ -15,7 +15,9 @@
             <th>Default due date</th>
             <th></th>
         <th></th>
-        <th></th>
+        <% if can? :delete, CommonTask %>
+          <th></th>
+        <% end %>
       </tr>
     </thead>
 
@@ -26,7 +28,9 @@
             <td><%= common_task.try(:date_modifier) %></td>
             <td><%= link_to 'Show', common_task %></td>
         <td><%= link_to 'Edit', edit_common_task_path(common_task) %></td>
-        <td><%= link_to 'Destroy', common_task, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% if can? :delete, CommonTask %>
+          <td><%= link_to 'Destroy', common_task, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% end %>
       <% end %>
     </tbody>
   </table>

--- a/app/views/extracurricular_activities/index.html.erb
+++ b/app/views/extracurricular_activities/index.html.erb
@@ -13,7 +13,9 @@
             <th>Name</th>
             <th></th>
         <th></th>
-        <th></th>
+        <% if can? :delete, ExtracurricularActivity %>
+          <th></th>
+        <% end %>
       </tr>
     </thead>
 
@@ -22,7 +24,9 @@
             <td><%= extracurricular_activity.name %></td>
             <td><%= link_to 'Show', extracurricular_activity %></td>
         <td><%= link_to 'Edit', edit_extracurricular_activity_path(extracurricular_activity) %></td>
-        <td><%= link_to 'Destroy', extracurricular_activity, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% if can? :delete, ExtracurricularActivity %>
+          <td><%= link_to 'Destroy', extracurricular_activity, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% end %>
       <% end %>
     </tbody>
   </table>

--- a/app/views/graduating_classes/index.html.erb
+++ b/app/views/graduating_classes/index.html.erb
@@ -13,7 +13,9 @@
             <th>Year</th>
             <th></th>
         <th></th>
+       <% if can? :delete, GraduatingClass %> 
         <th></th>
+      <% end %>
       </tr>
     </thead>
 
@@ -22,7 +24,9 @@
             <td><%= graduating_class.year %></td>
             <td><%= link_to 'Show', graduating_class %></td>
         <td><%= link_to 'Edit', edit_graduating_class_path(graduating_class) %></td>
-        <td><%= link_to 'Destroy', graduating_class, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+         <% if can? :delete, GraduatingClass %> 
+          <td><%= link_to 'Destroy', graduating_class, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% end %>
       <% end %>
     </tbody>
   </table>

--- a/app/views/identities/index.html.erb
+++ b/app/views/identities/index.html.erb
@@ -13,7 +13,9 @@
             <th>Name</th>
             <th></th>
         <th></th>
-        <th></th>
+        <% if can? :delete, Identity %>
+          <th></th>
+        <% end %>
       </tr>
     </thead>
 
@@ -22,7 +24,9 @@
             <td><%= identity.name %></td>
             <td><%= link_to 'Show', identity %></td>
         <td><%= link_to 'Edit', edit_identity_path(identity) %></td>
-        <td><%= link_to 'Destroy', identity, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% if can? :delete, Identity %>
+          <td><%= link_to 'Destroy', identity, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% end %>
       <% end %>
     </tbody>
   </table>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <% if user_signed_in? %>
-            <% if current_user.admin? %>
+            <% if current_user.admin? or current_user.staff? %>
               <ul class="nav navbar-nav">
                 <li><%= link_to('Members', members_path) %></li>
                 <li><%= link_to('Events', network_events_path) %></li>
@@ -40,7 +40,7 @@
                   <%= current_user.email %> <span class="caret"></span>
                 </a>
                   <ul class="dropdown-menu">
-                    <% if current_user.admin? %>
+                    <% if current_user.admin? or current_user.staff? %>
                       <li><%= link_to('Cohorts', cohorts_path) %></li>
                       <li><%= link_to('Extracurricular Activities', extracurricular_activities_path) %></li>
                       <li><%= link_to('Graduating classes', graduating_classes_path) %></li>

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -13,7 +13,9 @@
             <th>Name</th>
             <th></th>
         <th></th>
-        <th></th>
+        <% if can? :delete, Location %>
+          <th></th>
+        <% end %>
       </tr>
     </thead>
 
@@ -22,7 +24,9 @@
             <td><%= location.name %></td>
             <td><%= link_to 'Show', location %></td>
         <td><%= link_to 'Edit', edit_location_path(location) %></td>
-        <td><%= link_to 'Destroy', location, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% if can? :delete, Location %>
+          <td><%= link_to 'Destroy', location, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% end %>
       <% end %>
     </tbody>
   </table>

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -136,7 +136,9 @@
         <th>Email</th>
         <th></th>
         <th></th>
-        <th></th>
+        <% if can? :delete, Member %>
+          <th></th>
+        <% end %>
       </tr>
     </thead>
 
@@ -148,7 +150,9 @@
         <td><%= mail_to member.email %></td>
         <td><%= link_to 'Show', member %></td>
         <td><%= link_to 'Edit', edit_member_path(member) %></td>
+        <% if can? :delete, Member %>
         <td><%= link_to 'Destroy', member, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% end %>
       <% end %>
     </tbody>
   </table>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -132,7 +132,9 @@
           <th>Contacted on</th> 
           <th></th>
           <th></th>
-          <th></th>
+          <% if can? :delete, Communication %>
+            <th></th>
+          <% end %>
         </tr>
       </thead>
 
@@ -143,7 +145,9 @@
           <td><%= communication.contacted_on %></td>
           <td><%= link_to 'Show', member_communication_path(@member, communication) %></td>
           <td><%= link_to 'Edit', edit_member_communication_path(@member, communication) %></td>
-          <td><%= link_to 'Destroy', member_communication_path(@member, communication), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+          <% if can? :delete, Communication %>
+            <td><%= link_to 'Destroy', member_communication_path(@member, communication), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+          <% end %>
         <% end %>
       </tbody>
     </table>

--- a/app/views/neighborhoods/index.html.erb
+++ b/app/views/neighborhoods/index.html.erb
@@ -13,7 +13,9 @@
             <th>Name</th>
             <th></th>
         <th></th>
-        <th></th>
+        <% if can? :delete, Neighborhood %>
+          <th></th>
+        <% end %>
       </tr>
     </thead>
 
@@ -22,7 +24,9 @@
         <td><%= neighborhood.name %></td>
         <td><%= link_to 'Show', neighborhood %></td>
         <td><%= link_to 'Edit', edit_neighborhood_path(neighborhood) %></td>
-        <td><%= link_to 'Destroy', neighborhood, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% if can? :delete, Neighborhood %>
+          <td><%= link_to 'Destroy', neighborhood, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% end %>
       <% end %>
     </tbody>
   </table>

--- a/app/views/network_events/index.html.erb
+++ b/app/views/network_events/index.html.erb
@@ -164,7 +164,9 @@
           <th><%= sortable "scheduled_at", "Scheduled at"%></th>
           <th></th>
           <th></th>
-          <th></th>
+          <% if can? :destroy, NetworkEvent %> 
+            <th></th>
+          <% end %>
           <th></th>
         </tr>
       </thead>
@@ -181,8 +183,11 @@
           <td><%= network_event.scheduled_at.try(:to_formatted_s, :long)%></td>
           <td><%= link_to 'Show', network_event %></td>
           <td><%= link_to 'Edit', edit_network_event_path(network_event) %></td>
-          <td><%= link_to 'Destroy', network_event, method: :delete, data: { confirm: 'Are you sure?' } %></td>
-          <td><%= button_tag "Clip", type: 'button', data: {"clipboard-text" => clip_event_info(network_event), "toggle" => "tooltip", "placement" => "right"}, :title => clip_event_info(network_event), :class =>'clip_button btn btn-primary'%></td>
+          <% if can? :destroy, network_event %> 
+            <td>
+              <%= link_to 'Destroy', network_event, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+              <% end %>
+            <td><%= button_tag "Clip", type: 'button', data: {"clipboard-text" => clip_event_info(network_event), "toggle" => "tooltip", "placement" => "right"}, :title => clip_event_info(network_event), :class =>'clip_button btn btn-primary'%></td>
         <% end %>
       </tbody>
     </table>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -13,7 +13,9 @@
             <th>Name</th>
             <th></th>
         <th></th>
-        <th></th>
+        <% if can? :delete, Organization %>
+          <th></th>
+        <% end %>
       </tr>
     </thead>
 
@@ -22,7 +24,9 @@
             <td><%= organization.name %></td>
             <td><%= link_to 'Show', organization %></td>
         <td><%= link_to 'Edit', edit_organization_path(organization) %></td>
-        <td><%= link_to 'Destroy', organization, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% if can? :delete, Organization %>
+          <td><%= link_to 'Destroy', organization, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% end %>
       <% end %>
     </tbody>
   </table>

--- a/app/views/programs/index.html.erb
+++ b/app/views/programs/index.html.erb
@@ -14,7 +14,9 @@
             <th>Abbreviation</th>
         <th></th>
         <th></th>
-        <th></th>
+        <% if can? :delete, Program %>
+          <th></th>
+        <% end %>
       </tr>
     </thead>
 
@@ -24,7 +26,9 @@
             <td><%= program.abbreviation %></td>
             <td><%= link_to 'Show', program %></td>
         <td><%= link_to 'Edit', edit_program_path(program) %></td>
-        <td><%= link_to 'Destroy', program, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% if can? :delete, Program %>
+          <td><%= link_to 'Destroy', program, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% end %>
       <% end %>
     </tbody>
   </table>

--- a/app/views/schools/index.html.erb
+++ b/app/views/schools/index.html.erb
@@ -13,7 +13,9 @@
             <th>Name</th>
             <th></th>
         <th></th>
-        <th></th>
+        <% if can? :delete, School %>
+          <th></th>
+        <% end %>
       </tr>
     </thead>
 
@@ -22,7 +24,9 @@
             <td><%= school.name %></td>
             <td><%= link_to 'Show', school %></td>
         <td><%= link_to 'Edit', edit_school_path(school) %></td>
-        <td><%= link_to 'Destroy', school, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% if can? :delete, School %> 
+          <td><%= link_to 'Destroy', school, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% end %>
       <% end %>
     </tbody>
   </table>

--- a/app/views/talents/index.html.erb
+++ b/app/views/talents/index.html.erb
@@ -13,7 +13,9 @@
             <th>Name</th>
             <th></th>
         <th></th>
-        <th></th>
+        <% if can? :delete, Talent %>
+          <th></th>
+        <% end %>
       </tr>
     </thead>
 
@@ -22,7 +24,9 @@
             <td><%= talent.name %></td>
             <td><%= link_to 'Show', talent %></td>
         <td><%= link_to 'Edit', edit_talent_path(talent) %></td>
-        <td><%= link_to 'Destroy', talent, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% if can? :delete, Talent %>
+          <td><%= link_to 'Destroy', talent, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% end %>
       <% end %>
     </tbody>
   </table>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -25,6 +25,12 @@
     </div>
   </div>
   <div class="form-group">
+    <%= f.label :staff, class: "col-sm-2 control-label" %>
+    <div class="col-sm-10">
+      <%= f.check_box :staff, class: "form-control" %>
+    </div>
+  </div>
+  <div class="form-group">
     <div class="col-sm-offset-2 col-sm-10">
       <%= f.submit class: "btn btn-primary" %>
     </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -9,7 +9,9 @@
         <th>Email</th>
         <th></th>
         <th></th>
-        <th></th>
+        <% if can? :delete, User %>
+          <th></th>
+        <% end %>
       </tr>
     </thead>
 
@@ -18,7 +20,9 @@
         <td><%= mail_to user.email %></td>
         <td><%= link_to 'Show', user, method: :get %></td>
         <td><%= link_to 'Edit', edit_user_path(user) %></td>
-        <td><%= link_to 'Destroy', user, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% if can? :delete, User %>
+          <td><%= link_to 'Destroy', user, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% end %>
       <% end %>
     </tbody>
   </table>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -13,6 +13,9 @@
   <dt>Admin?:</dt>
   <dd><%= @user.admin?.to_s.capitalize %></dd>
 
+  <dt>Staff?:</dt>
+  <dd><%= @user.staff?.to_s.capitalize %></dd>
+  
   <dt>Sign in count:</dt>
   <dd><%= @user.sign_in_count %></dd>
 

--- a/db/migrate/20170906165326_add_staff_to_users.rb
+++ b/db/migrate/20170906165326_add_staff_to_users.rb
@@ -1,0 +1,5 @@
+class AddStaffToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :staff, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170906163338) do
+ActiveRecord::Schema.define(version: 20170906165326) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -177,9 +177,11 @@ ActiveRecord::Schema.define(version: 20170906163338) do
     t.datetime "due_date"
     t.string "date_modifier"
     t.integer "owner_id"
+    t.bigint "parent_id"
     t.index ["common_task_id"], name: "index_network_event_tasks_on_common_task_id"
     t.index ["network_event_id"], name: "index_network_event_tasks_on_network_event_id"
     t.index ["owner_id"], name: "index_network_event_tasks_on_owner_id"
+    t.index ["parent_id"], name: "index_network_event_tasks_on_parent_id"
   end
 
   create_table "network_events", force: :cascade do |t|
@@ -300,6 +302,7 @@ ActiveRecord::Schema.define(version: 20170906163338) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "admin", default: false
+    t.boolean "staff"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
@@ -312,4 +315,5 @@ ActiveRecord::Schema.define(version: 20170906163338) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "network_event_tasks", "network_event_tasks", column: "parent_id"
 end

--- a/test/controllers/cohorts_controller_test.rb
+++ b/test/controllers/cohorts_controller_test.rb
@@ -71,4 +71,10 @@ class CohortsControllerTest < ActionController::TestCase
 
     assert_redirected_to cohorts_path
   end
+  
+  test "staff user shouldn't be able to delete cohort" do
+    user = User.create!(email: 'test@example.com', staff: true, password: 'abcdef') 
+    ability = Ability.new(user)
+    assert ability.cannot? :delete, @cohort
+  end 
 end

--- a/test/controllers/common_tasks_controller_test.rb
+++ b/test/controllers/common_tasks_controller_test.rb
@@ -49,4 +49,10 @@ class CommonTasksControllerTest < ActionController::TestCase
 
     assert_redirected_to common_tasks_path
   end
+  
+  test "staff user shouldn't be able to delete common_task" do
+    user = User.create!(email: 'test@example.com', staff: true, password: 'abcdef') 
+    ability = Ability.new(user)
+    assert ability.cannot? :delete, @common_task
+  end
 end

--- a/test/controllers/communications_controller_test.rb
+++ b/test/controllers/communications_controller_test.rb
@@ -44,4 +44,10 @@ class CommunicationsControllerTest < ActionController::TestCase
 
     assert_redirected_to member_path
   end
+  
+  test "staff user shouldn't be able to delete communication" do
+    user = User.create!(email: 'test@example.com', staff: true, password: 'abcdef') 
+    ability = Ability.new(user)
+    assert ability.cannot? :delete, @communication
+  end
 end

--- a/test/controllers/extracurricular_activities_controller_test.rb
+++ b/test/controllers/extracurricular_activities_controller_test.rb
@@ -49,4 +49,10 @@ class ExtracurricularActivitiesControllerTest < ActionController::TestCase
 
     assert_redirected_to extracurricular_activities_path
   end
+  
+  test "staff user shouldn't be able to delete extracurricular_activities" do
+    user = User.create!(email: 'test@example.com', staff: true, password: 'abcdef') 
+    ability = Ability.new(user)
+    assert ability.cannot? :delete, @extracurricular_activity
+  end
 end

--- a/test/controllers/graduating_classes_controller_test.rb
+++ b/test/controllers/graduating_classes_controller_test.rb
@@ -49,4 +49,10 @@ class GraduatingClassesControllerTest < ActionController::TestCase
 
     assert_redirected_to graduating_classes_path
   end
+  
+  test "staff user shouldn't be able to delete graduating_classes" do
+    user = User.create!(email: 'test@example.com', staff: true, password: 'abcdef') 
+    ability = Ability.new(user)
+    assert ability.cannot? :delete, @graduating_class
+  end
 end

--- a/test/controllers/identities_controller_test.rb
+++ b/test/controllers/identities_controller_test.rb
@@ -49,4 +49,10 @@ class IdentitiesControllerTest < ActionController::TestCase
 
     assert_redirected_to identities_path
   end
+  
+  test "staff user shouldn't be able to delete identity" do
+    user = User.create!(email: 'test@example.com', staff: true, password: 'abcdef') 
+    ability = Ability.new(user)
+    assert ability.cannot? :delete, @identity
+  end
 end

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -49,4 +49,10 @@ class LocationsControllerTest < ActionController::TestCase
 
     assert_redirected_to locations_path
   end
+  
+  test "staff user shouldn't be able to delete location" do
+    user = User.create!(email: 'test@example.com', staff: true, password: 'abcdef') 
+    ability = Ability.new(user)
+    assert ability.cannot? :delete, @location
+  end
 end

--- a/test/controllers/members_controller_test.rb
+++ b/test/controllers/members_controller_test.rb
@@ -197,5 +197,11 @@ class MembersControllerTest < ActionController::TestCase
 
     assert_equal members(:george).name, member_json["text"]
   end
+  
+  test "staff user shouldn't be able to delete members" do
+    user = User.create!(email: 'test@example.com', staff: true, password: 'abcdef') 
+    ability = Ability.new(user)
+    assert ability.cannot? :delete, @member
+  end
 
 end

--- a/test/controllers/neighborhoods_controller_test.rb
+++ b/test/controllers/neighborhoods_controller_test.rb
@@ -49,4 +49,10 @@ class NeighborhoodsControllerTest < ActionController::TestCase
 
     assert_redirected_to neighborhoods_path
   end
+  
+  test "staff user shouldn't be able to delete neighborhood" do
+    user = User.create!(email: 'test@example.com', staff: true, password: 'abcdef') 
+    ability = Ability.new(user)
+    assert ability.cannot? :delete, @neighborhood
+  end
 end

--- a/test/controllers/network_actions_controller_test.rb
+++ b/test/controllers/network_actions_controller_test.rb
@@ -49,4 +49,10 @@ class NetworkActionsControllerTest < ActionController::TestCase
 
     assert_redirected_to network_actions_path
   end
+  
+  test "staff user shouldn't be able to delete network_action" do
+    user = User.create!(email: 'test@example.com', staff: true, password: 'abcdef') 
+    ability = Ability.new(user)
+    assert ability.cannot? :delete, @network_action
+  end
 end

--- a/test/controllers/network_event_tasks_controller_test.rb
+++ b/test/controllers/network_event_tasks_controller_test.rb
@@ -88,4 +88,10 @@ class NetworkEventTasksControllerTest < ActionController::TestCase
     end
     assert_response :success
   end
+  
+  test "staff user shouldn't be able to delete network_event_task" do
+    user = User.create!(email: 'test@example.com', staff: true, password: 'abcdef') 
+    ability = Ability.new(user)
+    assert ability.cannot? :delete, @network_event_task
+  end
 end

--- a/test/controllers/network_events_controller_test.rb
+++ b/test/controllers/network_events_controller_test.rb
@@ -155,7 +155,12 @@ class NetworkEventsControllerTest < ActionController::TestCase
     assert_difference('NetworkEvent.count', -1) do
       delete :destroy, params: { id: @network_event }
     end
-
     assert_redirected_to network_events_path
+  end
+  
+  test "staff user shouldn't be able to delete network_event" do
+    user = User.create!(email: 'test@example.com', staff: true, password: 'abcdef') 
+    ability = Ability.new(user)
+    assert ability.cannot? :delete, @network_event
   end
 end

--- a/test/controllers/organizations_controller_test.rb
+++ b/test/controllers/organizations_controller_test.rb
@@ -49,4 +49,10 @@ class OrganizationsControllerTest < ActionController::TestCase
 
     assert_redirected_to organizations_path
   end
+  
+  test "staff user shouldn't be able to delete organization" do
+    user = User.create!(email: 'test@example.com', staff: true, password: 'abcdef') 
+    ability = Ability.new(user)
+    assert ability.cannot? :delete, @organization
+  end
 end

--- a/test/controllers/programs_controller_test.rb
+++ b/test/controllers/programs_controller_test.rb
@@ -49,4 +49,10 @@ class ProgramsControllerTest < ActionController::TestCase
 
     assert_redirected_to programs_path
   end
+  
+  test "staff user shouldn't be able to delete programs" do
+    user = User.create!(email: 'test@example.com', staff: true, password: 'abcdef') 
+    ability = Ability.new(user)
+    assert ability.cannot? :delete, @program
+  end
 end

--- a/test/controllers/schools_controller_test.rb
+++ b/test/controllers/schools_controller_test.rb
@@ -49,4 +49,10 @@ class SchoolsControllerTest < ActionController::TestCase
 
     assert_redirected_to schools_path
   end
+  
+  test "staff user shouldn't be able to delete school" do
+    user = User.create!(email: 'test@example.com', staff: true, password: 'abcdef') 
+    ability = Ability.new(user)
+    assert ability.cannot? :delete, @school
+  end
 end

--- a/test/controllers/talents_controller_test.rb
+++ b/test/controllers/talents_controller_test.rb
@@ -49,4 +49,10 @@ class TalentsControllerTest < ActionController::TestCase
 
     assert_redirected_to talents_path
   end
+  
+  test "staff user shouldn't be able to delete talent" do
+    user = User.create!(email: 'test@example.com', staff: true, password: 'abcdef') 
+    ability = Ability.new(user)
+    assert ability.cannot? :delete, @talent
+  end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -26,5 +26,11 @@ class UsersControllerTest < ActionController::TestCase
 
     assert_redirected_to users_path
   end
+  
+  test "staff user shouldn't be able to delete user" do
+    user = User.create!(email: 'test@example.com', staff: true, password: 'abcdef') 
+    ability = Ability.new(user)
+    assert ability.cannot? :delete, @user
+  end
 
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -11,3 +11,4 @@ two:
 three:
   email: three@test.com
   admin: false
+  staff: true


### PR DESCRIPTION
Users must now be admins to delete important resources. Users with
the staff attribute are able to creade, read, update resources but are
unable to delete. #557 