### PR TITLE
Prevent member export from paginating

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -5,7 +5,11 @@ class MembersController < ApplicationController
   # GET /members
   # GET /members.json
   def index
-    @members = filtered_members.page params[:page]
+    @members = filtered_members
+    respond_to do |format|
+      format.any(:html, :json) { @members = @members.page params[:page] }
+      format.csv
+    end
   end
 
   # GET /members/1


### PR DESCRIPTION
The member export was paginating rather than returning all the results
that match the search criteria.  Now, if the request is an export to csv
then the pagination is skipped.