### PR TITLE
Separate event date and time copying

### DIFF
--- a/app/assets/javascripts/network_events.coffee
+++ b/app/assets/javascripts/network_events.coffee
@@ -26,9 +26,15 @@ $(document).on 'ready page:load turbolinks:load', ->
     else
       $('#order_div').hide()
       
-  $('#event-datetimepicker').datetimepicker({
+  $('#event-datepicker').datetimepicker({
       showClear: true,
-      format: 'YYYY-MM-DD hh:mm a',
+      format: 'YYYY-MM-DD',
+      useCurrent: false
+  })
+
+  $('#event-timepicker').datetimepicker({
+      showClear: true,
+      format: 'hh:mm a',
       useCurrent: false
   })
   

--- a/app/controllers/network_events_controller.rb
+++ b/app/controllers/network_events_controller.rb
@@ -51,6 +51,7 @@ class NetworkEventsController < ApplicationController
   # PATCH/PUT /network_events/1
   # PATCH/PUT /network_events/1.json
   def update
+    @network_event.scheduled_at = "#{(params[:network_event][:scheduled_at_date] + ' ' + params[:network_event][:scheduled_at_time]).to_datetime}"
     respond_to do |format|
       if @network_event.update(network_event_params)
         format.html { redirect_to @network_event, notice: 'Event was successfully updated.' }
@@ -100,6 +101,7 @@ class NetworkEventsController < ApplicationController
     def create_event
       @network_event = NetworkEvent.new(network_event_params)
       @network_event.user = current_user
+      @network_event.scheduled_at = "#{(params[:network_event][:scheduled_at_date] + ' ' + params[:network_event][:scheduled_at_time]).to_datetime}"
       respond_to do |format|
         if @network_event.save
           @network_event.network_event_tasks.each do |task|
@@ -123,6 +125,7 @@ class NetworkEventsController < ApplicationController
     end
 
     def override_params
+
       @override_params = network_event_params.select do |key, value|
         if value.is_a? Array
           value.present? && value.any?(&:present?)
@@ -130,6 +133,10 @@ class NetworkEventsController < ApplicationController
           value.present?
         end
       end
+      if params[:network_event][:scheduled_at_date].present? && params[:network_event][:scheduled_at_time].present?
+        @override_params[:scheduled_at] = "#{(params[:network_event][:scheduled_at_date] + ' ' + params[:network_event][:scheduled_at_time]).to_datetime}"
+      end
+      @override_params
     end
 
     # Use callbacks to share common setup or constraints between actions.
@@ -150,7 +157,7 @@ class NetworkEventsController < ApplicationController
       else
         events = events.default_date_range
       end
-      
+
       # Filter events by uncompleted tasks
       if params[:common_task_ids].present?
         events = events.
@@ -158,7 +165,7 @@ class NetworkEventsController < ApplicationController
           where(network_event_tasks: {common_task_id: params[:common_task_ids],
                                       completed_at: nil})
       end
-      
+
       # Filter events by cohort.
       if params[:cohort_ids].present?
         events = events.

--- a/app/views/network_events/_form.html.erb
+++ b/app/views/network_events/_form.html.erb
@@ -154,11 +154,21 @@
   <div class="form-group">
     <%= f.label :scheduled_at, class: "col-sm-2 control-label" %>
     <div class="col-sm-10">
-      <div class="input-group date" id="event-datetimepicker">
-         <input type='text' class="form-control" name="network_event[scheduled_at]" id="network_event_scheduled_at" value="<%= @network_event.scheduled_at %>" />
-                    <span class="input-group-addon">
-                        <span class="glyphicon glyphicon-calendar"></span>
-                    </span>
+      <div class="col-sm-6" style="padding-left:0;">
+        <div class="input-group date" id="event-datepicker">
+          <input type='text' class="form-control" name="network_event[scheduled_at_date]" id="network_event_scheduled_at" value="<%= @network_event.scheduled_at %>" />
+          <span class="input-group-addon">
+              <span class="glyphicon glyphicon-calendar"></span>
+          </span>
+        </div>
+      </div>
+      <div class="col-sm-6" style="padding-right: 0;">
+        <div class="input-group date" id="event-timepicker">
+          <input type='text' class="form-control" name="network_event[scheduled_at_time]" id="network_event_scheduled_at" value="<%= @network_event.scheduled_at %>" />
+          <span class="input-group-addon">
+              <span class="glyphicon glyphicon-time"></span>
+          </span>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- Replaced scheduled_at datetime field with seperate date and time field
- Added changes in controller to join date and time in controller to save as scheduled_at

In copy event if the scheduled_at date and time BOTH are provided ONLY then the scheduled_at is update for the copied events.

Ticket #545 