### PR TITLE
Added attendance cohorts to events

### DIFF
--- a/app/controllers/network_events_controller.rb
+++ b/app/controllers/network_events_controller.rb
@@ -150,7 +150,7 @@ class NetworkEventsController < ApplicationController
       else
         events = events.default_date_range
       end
-      
+
       # Filter events by uncompleted tasks
       if params[:common_task_ids].present?
         events = events.
@@ -158,7 +158,7 @@ class NetworkEventsController < ApplicationController
           where(network_event_tasks: {common_task_id: params[:common_task_ids],
                                       completed_at: nil})
       end
-      
+
       # Filter events by cohort.
       if params[:cohort_ids].present?
         events = events.
@@ -227,6 +227,7 @@ class NetworkEventsController < ApplicationController
         :volunteer_ids => [],
         :graduating_class_ids => [],
         :school_ids => [],
+        :attendance_cohort_ids => [],
         :cohort_ids => [],
         :network_event_tasks_attributes => [:id, :name, :scheduled_at, :common_task_id, :network_event_id, :owner_id, :due_date, :date_modifier]
       )

--- a/app/models/attendance_cohort_assignment.rb
+++ b/app/models/attendance_cohort_assignment.rb
@@ -1,0 +1,5 @@
+class AttendanceCohortAssignment < ApplicationRecord
+  belongs_to :network_event
+  belongs_to :cohort
+  belongs_to :user
+end

--- a/app/views/network_events/_form.html.erb
+++ b/app/views/network_events/_form.html.erb
@@ -27,11 +27,11 @@
     <div class="form-group">
       <%= f.label :status, class: "col-sm-2 control-label" %>
       <div class="col-sm-10">
-        <%= f.collection_select :status, 
-              NetworkEvent.statuses, 
-              :to_s, 
-              :titleize, 
-              { include_blank: true }, 
+        <%= f.collection_select :status,
+              NetworkEvent.statuses,
+              :to_s,
+              :titleize,
+              { include_blank: true },
               class: "select2 form-control" %>
       </div>
     </div>
@@ -39,11 +39,11 @@
   <div class="form-group">
     <%= f.label :program_id, class: "col-sm-2 control-label" %>
     <div class="col-sm-10">
-      <%= f.collection_select :program_id, 
-            Program.order(:name).all, 
-            :id, 
-            :name, 
-            { include_blank: true }, 
+      <%= f.collection_select :program_id,
+            Program.order(:name).all,
+            :id,
+            :name,
+            { include_blank: true },
             class: "select2 form-control",
             data: { placeholder: 'Find Program' } %>
     </div>
@@ -51,11 +51,11 @@
   <div class="form-group">
     <%= f.label :location_id, class: "col-sm-2 control-label" %>
     <div class="col-sm-10">
-      <%= f.collection_select :location_id, 
-            Location.order(:name).all, 
-            :id, 
-            :name, 
-            { include_blank: true }, 
+      <%= f.collection_select :location_id,
+            Location.order(:name).all,
+            :id,
+            :name,
+            { include_blank: true },
             class: "select2 form-control",
             data: { placeholder: 'Find Location' } %>
     </div>
@@ -63,91 +63,104 @@
   <div class="form-group">
     <%= f.label :organization_ids, 'Organizations', class: "col-sm-2 control-label" %>
     <div class="col-sm-10">
-      <%= f.collection_select :organization_ids, 
-            Organization.order(:name).all, 
-            :id, 
-            :name, 
-            {}, 
+      <%= f.collection_select :organization_ids,
+            Organization.order(:name).all,
+            :id,
+            :name,
+            {},
             class: "select2 form-control",
-            multiple: true, 
+            multiple: true,
             data: { placeholder: 'Find Organizations' }  %>
     </div>
   </div>
   <div class="form-group">
     <%= f.label :site_contact_ids, 'Site Contacts', class: "col-sm-2 control-label" %>
     <div class="col-sm-10">
-      <%= f.collection_select :site_contact_ids, 
-            @network_event.site_contacts, 
-            :id, 
-            :text, 
-            {}, 
-            class: "select2 ajax form-control", 
-            multiple: true, 
+      <%= f.collection_select :site_contact_ids,
+            @network_event.site_contacts,
+            :id,
+            :text,
+            {},
+            class: "select2 ajax form-control",
+            multiple: true,
             data: { ajax: { url: members_path }, placeholder: 'Find Site Contacts' }  %>
     </div>
   </div>
   <div class="form-group">
     <%= f.label :school_contact_ids, 'School Contacts', class: "col-sm-2 control-label" %>
     <div class="col-sm-10">
-      <%= f.collection_select :school_contact_ids, 
-            @network_event.school_contacts, 
-            :id, 
-            :text, 
-            {}, 
-            class: "select2 ajax form-control", 
-            multiple: true, 
+      <%= f.collection_select :school_contact_ids,
+            @network_event.school_contacts,
+            :id,
+            :text,
+            {},
+            class: "select2 ajax form-control",
+            multiple: true,
             data: { ajax: { url: members_path }, placeholder: 'Find School Contacts' }  %>
     </div>
   </div>
   <div class="form-group">
     <%= f.label :volunteer_ids, 'Volunteers', class: "col-sm-2 control-label" %>
     <div class="col-sm-10">
-      <%= f.collection_select :volunteer_ids, 
-            @network_event.volunteers, 
-            :id, 
-            :text, 
-            {}, 
-            class: "select2 ajax form-control", 
-            multiple: true, 
+      <%= f.collection_select :volunteer_ids,
+            @network_event.volunteers,
+            :id,
+            :text,
+            {},
+            class: "select2 ajax form-control",
+            multiple: true,
             data: { ajax: { url: members_path }, placeholder: 'Find Volunteers' }  %>
     </div>
   </div>
   <div class="form-group">
     <%= f.label :school_ids, 'Schools', class: "col-sm-2 control-label" %>
     <div class="col-sm-10">
-      <%= f.collection_select :school_ids, 
-            School.order(:name).all, 
-            :id, 
-            :name, 
-            {}, 
-            class: "select2 form-control", 
-            multiple: true, 
+      <%= f.collection_select :school_ids,
+            School.order(:name).all,
+            :id,
+            :name,
+            {},
+            class: "select2 form-control",
+            multiple: true,
             data: { placeholder: 'Find Schools' }  %>
     </div>
   </div>
   <div class="form-group">
     <%= f.label :graduating_class_ids, 'Graduating Classes', class: "col-sm-2 control-label" %>
     <div class="col-sm-10">
-      <%= f.collection_select :graduating_class_ids, 
-            GraduatingClass.order(:year).all, 
-            :id, 
-            :name, 
-            {}, 
-            class: "select2 form-control", 
-            multiple: true, 
+      <%= f.collection_select :graduating_class_ids,
+            GraduatingClass.order(:year).all,
+            :id,
+            :name,
+            {},
+            class: "select2 form-control",
+            multiple: true,
             data: { placeholder: 'Find Graduating Classes' }  %>
     </div>
   </div>
   <div class="form-group">
-    <%= f.label :cohort_ids, 'Cohorts', class: "col-sm-2 control-label" %>
+    <%= f.label :attendance_cohort_ids, 'Attendance Cohorts', class: "col-sm-2 control-label" %>
     <div class="col-sm-10">
-      <%= f.collection_select :cohort_ids, 
-            Cohort.active_cohorts, 
-            :id, 
-            :name, 
-            {}, 
-            class: "select2 form-control", 
-            multiple: true, 
+      <%= f.collection_select :attendance_cohort_ids,
+            Cohort.active_cohorts,
+            :id,
+            :name,
+            {},
+            class: "select2 form-control",
+            multiple: true,
+            data: { placeholder: 'Find Attendance Cohorts' }  %>
+    </div>
+  </div>
+  <div class="form-group">
+    <%= f.label :cohort_ids, 'Cohorts Served', class: "col-sm-2 control-label" %>
+    <div class="col-sm-10">
+      <%= f.collection_select :cohort_ids,
+            Cohort.active_cohorts,
+            :id,
+            :name,
+            {},
+            class: "select2 form-control",
+            multiple: true,
             data: { placeholder: 'Find Cohorts' }  %>
     </div>
   </div>
@@ -171,10 +184,10 @@
   <div class="form-group">
     <%= f.label :needs_transport, 'Transportation Needed', class: "col-sm-2 control-label" %>
     <div class="col-sm-10">
-      <%= f.select :needs_transport, 
-            [["Yes", true], ["No", false]], 
-            { include_blank: " " }, 
-            class: "select2 form-control", 
+      <%= f.select :needs_transport,
+            [["Yes", true], ["No", false]],
+            { include_blank: " " },
+            class: "select2 form-control",
             data: { placeholder: 'Transportation Needed?' }  %>
     </div>
   </div>

--- a/app/views/network_events/show.html.erb
+++ b/app/views/network_events/show.html.erb
@@ -77,7 +77,16 @@
     <dd></dd>
   <% end %>
 
-  <dt>Cohorts:</dt>
+  <dt>Attendance Cohorts:</dt>
+  <% if @network_event.attendance_cohorts.present? %>
+    <%= content_tag_for(:dd, @network_event.attendance_cohorts) do |cohort| %>
+      <%= cohort.name %>
+    <% end %>
+  <% else %>
+    <dd></dd>
+  <% end %>
+
+  <dt>Cohorts Served:</dt>
   <% if @network_event.cohorts.present? %>
     <%= content_tag_for(:dd, @network_event.cohorts) do |cohort| %>
       <%= cohort.name %>
@@ -94,16 +103,16 @@
         <%= @network_event.stop_time %>
       <% end %>
   </dd>
-      
+
   <dt>Transportation needed:</dt>
   <dd><%= @network_event.needs_transport %></dd>
 
   <dt>Transportation ordered:</dt>
   <dd><%= @network_event.transport_ordered_on %></dd>
-  
+
   <dt>Notes:</dt>
   <dd><%= @network_event.notes %></dd>
-  
+
   <dt>Creator:</dt>
   <dd><%= @network_event.user.try(:email) %></dd>
 
@@ -142,7 +151,7 @@
           <th></th>
         </tr>
       </thead>
-  
+
       <tbody>
         <%= content_tag_for(:tr, @network_event.network_event_tasks) do |task| %>
           <td class="task_name"><a class="task-name" data-url="/network_event_tasks/<%= task.id %>"><%= task.name %></a></td>
@@ -159,14 +168,14 @@
               </div>
             </div>
           <td class="task_completed_at"><%= task.formatted_completed_at %> </td>
-          <td class="task_owner"><a class="task-owner" data-url="/network_event_tasks/<%= task.id %>" 
+          <td class="task_owner"><a class="task-owner" data-url="/network_event_tasks/<%= task.id %>"
                data-source="<%= User.editable_options %>"><%= task.owner.try(:email) %></a></td>
           <td class="task_mark">
             <% if not task.completed_at.present? %>
               <%= button_to("Mark Completed", network_event_task_path(task) , remote: true, method: :patch, name: "task_button", class:"btn btn-primary task_button",
                             params: { :"network_event_task[completed_at]" => Time.now }) %>
             <% else %>
-              Completed 
+              Completed
             <% end %>
           </td>
           <td><%= link_to 'Destroy', task, method: :delete, remote: true, data: { confirm: 'Are you sure?' } %></td>
@@ -182,7 +191,7 @@
       <div class="form-group">
         <%= f.label :name %>
           <%= f.text_field :name, class:"form-control", id: 'task-name' %>
-          <%= f.hidden_field :network_event_id, value: @network_event.id %> 
+          <%= f.hidden_field :network_event_id, value: @network_event.id %>
       </div>
       <div class="form-group">
         <%= f.label :owner %>

--- a/db/migrate/20171019132839_add_attendance_cohort_assignment.rb
+++ b/db/migrate/20171019132839_add_attendance_cohort_assignment.rb
@@ -1,0 +1,11 @@
+class AddAttendanceCohortAssignment < ActiveRecord::Migration[5.1]
+  def change
+    create_table :attendance_cohort_assignments do |t|
+      t.integer :network_event_id
+      t.integer :cohort_id
+      t.integer :user_id
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170906165326) do
+ActiveRecord::Schema.define(version: 20171019132839) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,6 +18,14 @@ ActiveRecord::Schema.define(version: 20170906165326) do
   create_table "affiliations", force: :cascade do |t|
     t.integer "member_id"
     t.integer "organization_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "attendance_cohort_assignments", force: :cascade do |t|
+    t.integer "network_event_id"
+    t.integer "cohort_id"
+    t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/test/fixtures/attendance_cohort_assignments.yml
+++ b/test/fixtures/attendance_cohort_assignments.yml
@@ -1,0 +1,21 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+tuggle_purple:
+  network_event: tuggle_network
+  cohort: purple
+  user: one
+
+tuggle_green:
+  network_event: tuggle_network
+  cohort: green
+  user: one
+
+carver_red:
+  network_event: carver_tour
+  cohort: red
+  user: one
+  
+carver_blue:
+  network_event: carver_tour
+  cohort: blue
+  user: one

--- a/test/models/network_event_test.rb
+++ b/test/models/network_event_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class NetworkEventTest < ActiveSupport::TestCase
-  
+
   def network_event_attributes(additional_attributes={})
     {
       name: 'Test',
@@ -9,258 +9,322 @@ class NetworkEventTest < ActiveSupport::TestCase
       scheduled_at: 1.day.from_now,
       location: locations(:tuggle)
     }.merge(additional_attributes)
-  end 
-  
+  end
+
   test "NetworkEvent invitees requires cohort, school or graduating class" do
     network_event = NetworkEvent.create!(network_event_attributes)
-    
+
     assert_empty network_event.invitees
-  end 
-  
+  end
+
   test "Network invitees should be constrained by graduation class" do
     network_event = NetworkEvent.create!(
       network_event_attributes(
         graduating_class_ids: [graduating_classes(:class_of_2016).id]
       )
     )
-    
+
     assert_includes network_event.invitees, members(:one)
     refute_includes network_event.invitees, members(:two)
   end
-  
+
+  test "Network invitees should be constrained by school" do
+    network_event = NetworkEvent.create!(
+      network_event_attributes(
+        school_ids: [schools(:carver).id]
+      )
+    )
+
+    assert_includes network_event.invitees, members(:one)
+    refute_includes network_event.invitees, members(:three)
+  end
+
+  test "Network invitees should be constrained by cohort" do
+    network_event = NetworkEvent.create!(
+      network_event_attributes(
+        attendance_cohort_ids: [cohorts(:purple).id]
+      )
+    )
+
+    assert_includes network_event.invitees, members(:martin)
+    refute_includes network_event.invitees, members(:rosa)
+  end
+
+  test "Network invitees should be included by any cohort" do
+    network_event = NetworkEvent.create!(
+      network_event_attributes(
+        attendance_cohort_ids: [cohorts(:purple).id, cohorts(:green).id]
+      )
+    )
+
+    assert_includes network_event.invitees, members(:martin)
+    assert_includes network_event.invitees, members(:rosa)
+  end
+
   test "When a network event is copied the id should be present" do
     original = network_events(:tuggle_network)
     copy = original.copy
     assert copy.id.present?
   end
-  
+
   test "When a network event is copied the id should be different" do
     original = network_events(:tuggle_network)
     copy = original.copy
     refute_equal original.id, copy.id
   end
-  
+
   test "When a network event is copied the name should be the same" do
     original = network_events(:tuggle_network)
-    assert_guard original.name.present?, 
+    assert_guard original.name.present?,
       "Network event fixture expected to have a name"
-      
+
     copy = original.copy
     assert_equal original.name, copy.name
   end
-  
+
   test "When a network event is copied, scheduled at should be the empty" do
     original = network_events(:tuggle_network)
-    assert_guard original.scheduled_at.present?, 
+    assert_guard original.scheduled_at.present?,
       "Network event fixture expected to have a scheduled at date/time"
-      
+
     copy = original.copy
     assert_nil copy.scheduled_at
   end
-  
+
   test "When a network event is copied the created at date should be different" do
     original = network_events(:tuggle_network)
-    assert_guard original.created_at.present?, 
+    assert_guard original.created_at.present?,
       "Network event fixture expected to have a created at date/time"
-      
+
     copy = original.copy
     refute_equal original.created_at, copy.created_at
   end
-  
+
   test "When a network event is copied the created at date should be present" do
     original = network_events(:tuggle_network)
     copy = original.copy
     refute_nil copy.created_at
   end
-  
+
   test "When a network event is copied the updated at date should be different" do
     original = network_events(:tuggle_network)
-    assert_guard original.updated_at.present?, 
+    assert_guard original.updated_at.present?,
       "Network event fixture expected to have a updated at date/time"
-      
+
     copy = original.copy
     refute_equal original.updated_at, copy.updated_at
   end
-  
+
   test "When a network event is copied the updated at date should be present" do
     original = network_events(:tuggle_network)
     copy = original.copy
     refute_nil copy.updated_at
   end
-  
+
   test "When a network event is copied the duration should be the same" do
     original = network_events(:tuggle_network)
-    assert_guard original.duration.present?, 
+    assert_guard original.duration.present?,
       "Network event fixture expected to have a duration"
-      
+
     copy = original.copy
     assert_equal original.duration, copy.duration
   end
-  
+
   test "When a network event is copied, needs transportation should be the same" do
     original = network_events(:tuggle_network)
-    assert_guard !original.needs_transport.nil?, 
+    assert_guard !original.needs_transport.nil?,
       "Network event fixture expected to have a needs transportation"
-      
+
     copy = original.copy
     assert_equal original.needs_transport, copy.needs_transport
   end
-  
+
   test "When a network event is copied the transport ordered on date should be empty" do
     original = network_events(:tuggle_network)
-    assert_guard original.transport_ordered_on.present?, 
+    assert_guard original.transport_ordered_on.present?,
       "Network event fixture expected to have a transport ordered on date"
-      
+
     copy = original.copy
     assert_nil copy.transport_ordered_on
   end
-  
+
   test "When a network event is copied the notes should be empty" do
     original = network_events(:tuggle_network)
-    assert_guard original.notes.present?, 
+    assert_guard original.notes.present?,
       "Network event fixture expected to have notes"
-      
+
     copy = original.copy
     assert_nil copy.notes
   end
-  
+
   test "When a network event is copied the status should be empty" do
     original = network_events(:tuggle_network)
-    assert_guard original.status.present?, 
+    assert_guard original.status.present?,
       "Network event fixture expected to have status"
-      
+
     copy = original.copy
     assert_nil copy.status
   end
-  
+
   test "When a network event is copied the program should be the same" do
     original = network_events(:tuggle_network)
-    assert_guard original.program.present?, 
+    assert_guard original.program.present?,
       "Network event fixture expected to have a program"
-      
+
     copy = original.copy
     assert_equal original.program, copy.program
   end
-  
+
   test "When a network event is copied the location should be the same" do
     original = network_events(:tuggle_network)
-    assert_guard original.location.present?, 
+    assert_guard original.location.present?,
       "Network event fixture expected to have a location"
-      
+
     copy = original.copy
     assert_equal original.location, copy.location
   end
-  
+
   test "When a network event is copied the user should be the same" do
     original = network_events(:tuggle_network)
-    assert_guard original.user.present?, 
+    assert_guard original.user.present?,
       "Network event fixture expected to have a user"
-      
+
     copy = original.copy
     assert_equal original.user, copy.user
   end
-  
+
   test "When a network event is copied the site contacts should be the same" do
     original = network_events(:tuggle_network)
-    assert_guard original.site_contacts.present?, 
+    assert_guard original.site_contacts.present?,
       "Network event fixture expected to have site contacts"
-      
+
     copy = original.copy
     assert_equal original.site_contacts, copy.site_contacts
   end
-  
+
   test "When a network event is copied the school contacts should be the same" do
     original = network_events(:tuggle_network)
-    assert_guard original.school_contacts.present?, 
+    assert_guard original.school_contacts.present?,
       "Network event fixture expected to have school contacts"
-      
+
     copy = original.copy
     assert_equal original.school_contacts, copy.school_contacts
   end
-  
+
   test "When a network event is copied the volunteers should be the same" do
     original = network_events(:tuggle_network)
-    assert_guard original.volunteers.present?, 
+    assert_guard original.volunteers.present?,
       "Network event fixture expected to have volunteers"
-      
+
     copy = original.copy
     assert_equal original.volunteers, copy.volunteers
   end
-  
+
   test "When a network event is copied the graduating classes should be the same" do
     original = network_events(:tuggle_network)
-    assert_guard original.graduating_classes.present?, 
+    assert_guard original.graduating_classes.present?,
       "Network event fixture expected to have graduating classes"
-      
+
     copy = original.copy
     assert_equal original.graduating_classes, copy.graduating_classes
   end
-  
+
   test "When a network event is copied the organizations should be the same" do
     original = network_events(:tuggle_network)
-    assert_guard original.organizations.present?, 
+    assert_guard original.organizations.present?,
       "Network event fixture expected to have organizations"
-      
+
     copy = original.copy
     assert_equal original.organizations, copy.organizations
   end
-  
+
   test "When a network event is copied the schools should be the same" do
     original = network_events(:tuggle_network)
-    assert_guard original.schools.present?, 
+    assert_guard original.schools.present?,
       "Network event fixture expected to have schools"
-      
+
     copy = original.copy
     assert_equal original.schools, copy.schools
   end
-  
+
   test "When a network event is copied the cohorts should be the same" do
     original = network_events(:tuggle_network)
-    assert_guard original.cohorts.present?, 
+    assert_guard original.cohorts.present?,
       "Network event fixture expected to have cohorts"
-      
+
     copy = original.copy
     assert_equal original.cohorts, copy.cohorts
   end
-  
+
   test "When a network event is copied the participants should not be copied" do
     original = network_events(:tuggle_network)
-    assert_guard original.participants.present?, 
+    assert_guard original.participants.present?,
       "Network event fixture expected to have participants"
-      
+
     copy = original.copy
     assert_empty copy.participants
   end
-  
+
   test "When a network event is copied the tasks should be the same" do
     original = network_events(:tuggle_network)
-    assert_guard original.network_event_tasks.present?, 
+    assert_guard original.network_event_tasks.present?,
       "Network event fixture expected to have tasks"
-      
+
     copy = original.copy
     assert_equal original.network_event_tasks.count, copy.network_event_tasks.count
   end
-  
+
   test "When a network event is copied the cohorts can be overridden" do
     original = network_events(:tuggle_network)
-    assert_guard original.cohorts.present?, 
+    assert_guard original.cohorts.present?,
       "Network event fixture expected to have cohorts"
-    assert_guard original.cohorts.exclude?(cohorts(:red)), 
+    assert_guard original.cohorts.exclude?(cohorts(:red)),
       "Network event fixture cohorts expected to not include red"
-      
+
     overrides = { cohort_ids: [cohorts(:red).id, cohorts(:purple).id]}
     copy = original.copy(overrides)
     assert_equal Cohort.where(id: overrides[:cohort_ids]), copy.cohorts
   end
-  
+
   test "When a network event is copied the cohorts can be removed" do
     original = network_events(:tuggle_network)
-    assert_guard original.cohorts.present?, 
+    assert_guard original.cohorts.present?,
       "Network event fixture expected to have cohorts"
-      
+
     overrides = { cohort_ids: []}
     copy = original.copy(overrides)
     assert_equal Cohort.where(id: overrides[:cohort_ids]), copy.cohorts
   end
-  
+
+  test "When a network event is copied the attendance cohorts should be the same" do
+    original = network_events(:tuggle_network)
+    assert_guard original.attendance_cohorts.present?,
+      "Network event fixture expected to have attendance cohorts"
+
+    copy = original.copy
+    assert_equal original.attendance_cohorts, copy.attendance_cohorts
+  end
+
+  test "When a network event is copied the attendance cohorts can be overridden" do
+    original = network_events(:tuggle_network)
+    assert_guard original.attendance_cohorts.present?,
+      "Network event fixture expected to have attendance cohorts"
+    assert_guard original.attendance_cohorts.exclude?(cohorts(:red)),
+      "Network event fixture attendance_cohorts expected to not include red"
+
+    overrides = { attendance_cohort_ids: [cohorts(:red).id, cohorts(:purple).id]}
+    copy = original.copy(overrides)
+    assert_equal Cohort.where(id: overrides[:attendance_cohort_ids]), copy.attendance_cohorts
+  end
+
+  test "When a network event is copied the attendance cohorts can be removed" do
+    original = network_events(:tuggle_network)
+    assert_guard original.attendance_cohorts.present?,
+      "Network event fixture expected to have attendance cohorts"
+
+    overrides = { attendance_cohort_ids: []}
+    copy = original.copy(overrides)
+    assert_equal Cohort.where(id: overrides[:attendance_cohort_ids]), copy.attendance_cohorts
+  end
+
 end


### PR DESCRIPTION
Cohorts were being used to specify who should attend an event as well
as who was served at an event.  When a subset of a cohort being served
was invited to attend then specifying both in one field would not work.
Now there are separate cohort fields for specifying who should attend and
who is being served.  This allows for one teacher's students in an academy
to be invited and to also indicate that the event targets the academy.
Otherwise, it would appear that the whole academy was invited to the event.