### PR TITLE
Add participation count to event show pages

### DIFF
--- a/app/views/network_events/show.html.erb
+++ b/app/views/network_events/show.html.erb
@@ -190,6 +190,7 @@
 </div>
 
 <h2>Participants</h2>
+<h3>Total: <%= @participations.length %></h3>
 
 <div class="table-responsive">
   <table class="table table-striped table-bordered table-hover">


### PR DESCRIPTION
The total number of participants in an event are now listed under the participant
heading to enable users to quickly tell how many participants were at an event.