### PR TITLE
Temporarily constrain report to 2017-2018 year

### DIFF
--- a/app/controllers/reports/students_by_program_controller.rb
+++ b/app/controllers/reports/students_by_program_controller.rb
@@ -5,14 +5,14 @@ class Reports::StudentsByProgramController < ApplicationController
     programs.name AS name_of_program,
     COUNT(participations.id) AS total_attendees,
     COUNT(DISTINCT participations.member_id) AS unique_attendees,
-    round(COUNT(participations.id)/count(DISTINCT network_events.id)) AS average_attendance
+    round(COUNT(participations.id)/COUNT(DISTINCT network_events.id)) AS average_attendance
     SELECT
 
     @rows = NetworkEvent.
       select(select_clause).
       joins(:program, :participations).
       group('programs.name').
-      where("participations.level = 'attendee'")
+      where("participations.level = 'attendee' AND network_events.scheduled_at > '2017/07/01'")
 
   end
 end


### PR DESCRIPTION
Until the star schema is complete with a date dimension, the attendees
by program report is constrained to the 2017-2018 school year so Ed
can get the need information.