### PR TITLE
Fixed average attendance and unique attendees

### DIFF
--- a/app/controllers/reports/students_by_program_controller.rb
+++ b/app/controllers/reports/students_by_program_controller.rb
@@ -14,5 +14,16 @@ class Reports::StudentsByProgramController < ApplicationController
       group('programs.name').
       where("participations.level = 'attendee' AND network_events.scheduled_at > '2017/07/01'")
 
+    @total_attendees = @rows.map(&:total_attendees).sum
+    @total_unique_attendees = Participation.
+      joins(:network_event).
+      where("participations.level = 'attendee' AND network_events.scheduled_at > '2017/07/01'").
+      distinct.
+      count(:member_id)
+    if @rows.present?
+      @average_attendance = @total_attendees / @rows.length
+    else
+      @average_attendance = 0
+    end
   end
 end

--- a/app/views/reports/students_by_program/index.html.erb
+++ b/app/views/reports/students_by_program/index.html.erb
@@ -31,9 +31,9 @@
         <th>Total</th>
         <th></th>
         <th></th>
-        <th><%= @rows.map(&:total_attendees).sum %></th>
-        <th><%= @rows.map(&:unique_attendees).sum %></th>
-        <th><%= @rows.map(&:average_attendance).sum.to_s(:rounded, precision: 1) %></th>
+        <th><%= @total_attendees %></th>
+        <th><%= @total_unique_attendees %></th>
+        <th><%= @average_attendance.to_s(:rounded, precision: 1) %></th>
       </tr>
     </tfoot>
   </table>


### PR DESCRIPTION
The total row for average attendance was summing the average
attendance of each program which was very incorrect.  Now it averages
the average attendance of each program which is better but probably
not accurate.

The total row for unique attendees was summing the unique attendees
for each program which is not correct.  An individual attendee could
attend events in two different programs and get counted twice in the
total row.  This was fixed by doing a separate query to get the total
unique attendees overall.