### PR TITLE
Compute average attendance when attendance has been taken

### DIFF
--- a/app/controllers/reports/events_by_program_controller.rb
+++ b/app/controllers/reports/events_by_program_controller.rb
@@ -7,7 +7,7 @@ class Reports::EventsByProgramController < ApplicationController
       SUM(programming_facts.event_count) AS event_count,
       SUM(programming_facts.hours) AS programming_hours,
       AVG(CASE
-        WHEN programming_facts.invitee_count > 0 THEN
+        WHEN programming_facts.invitee_count > 0 AND programming_facts.attendee_count > 0 THEN
           (programming_facts.attendee_count / programming_facts.invitee_count) * 100
         ELSE NULL
       END) AS attendance

--- a/app/views/reports/events_by_program/index.html.erb
+++ b/app/views/reports/events_by_program/index.html.erb
@@ -40,7 +40,7 @@
           <td><%= row.name_of_program %></td>
           <td><%= row.event_count %></td>
           <td><%= row.programming_hours.to_s(:rounded, precision: 1) %></td>
-          <td><%= row.attendance.to_s(:rounded, precision: 1) %></td>
+          <td><%= row.attendance.present? ? row.attendance.to_s(:rounded, precision: 1) : '' %></td>
         </tr>
       <% end %>
     </tbody>


### PR DESCRIPTION
Average attendance was being computed for events where attenance
had not been taken and it was skewing the results.