### PR TITLE
Updated rails-html-sanitizer gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,8 +163,8 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.0.3)
-      loofah (~> 2.0)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
     railties (5.1.1)
       actionpack (= 5.1.1)
       activesupport (= 5.1.1)
@@ -263,4 +263,4 @@ DEPENDENCIES
   zeroclipboard-rails
 
 BUNDLED WITH
-   1.15.4
+   1.16.2


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2018-3741

There is a possible XSS vulnerability in all rails-html-sanitizer gem
versions below 1.0.4 for Ruby. The gem allows non-whitelisted attributes
to be present in sanitized output when input with specially-crafted HTML
fragments, and these attributes can lead to an XSS attack on target
applications. This issue is similar to CVE-2018-8048 in Loofah.