### PR TITLE
Add the listen gem to development Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,9 @@ group :development do
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
+
+  # Listen for file updates in development mode rather than polling.
+  gem 'listen'
 end
 
 gem 'rollbar'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,10 @@ GEM
     letsencrypt-rails-heroku (1.2.0)
       acme-client (~> 0.4.0)
       platform-api
+    listen (3.1.5)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -198,6 +202,7 @@ GEM
       railties (>= 4.2.0, < 5.3)
     rollbar (2.16.2)
       multi_json
+    ruby_dep (1.5.0)
     sass (3.5.6)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -266,6 +271,7 @@ DEPENDENCIES
   jquery-rails
   kaminari
   letsencrypt-rails-heroku
+  listen
   momentjs-rails (>= 2.9.0)
   pg
   pg_search


### PR DESCRIPTION
The listen gem is used in development mode by Rails 5 to detect
changes to source files.