### PR TITLE
Add high school gpa to the member model

### DIFF
--- a/app/analytics/etl/dimensions/member.rb
+++ b/app/analytics/etl/dimensions/member.rb
@@ -9,7 +9,8 @@ class Etl::Dimensions::Member
                 school: member.school.try(:name),
                 city: member.city,
                 state: member.state,
-                zip: member.zip_code
+                zip: member.zip_code,
+                high_school_gpa: member.high_school_gpa
             }
 
             if MemberDimension.where(member_id: attributes[:member_id]).exists?

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -154,6 +154,34 @@ class MembersController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def member_params
-      params.require(:member).permit(:first_name, :last_name, :date_of_birth, :phone, :email, :identity, :affiliation, :address, :city, :state, :zip_code, :shirt_size, :shirt_received, :place_of_worship, :recruitment, :community_networks, :extra_groups, :other_networks, :graduating_class_id, :school_id, :identity_id, :organization_ids => [], :neighborhood_ids => [], :extracurricular_activity_ids => [], talent_ids: [], :cohort_ids => [])
+      params.require(:member).permit(
+        :first_name, 
+        :last_name, 
+        :date_of_birth, 
+        :phone, 
+        :email, 
+        :identity, 
+        :affiliation, 
+        :address, 
+        :city, 
+        :state, 
+        :zip_code, 
+        :shirt_size, 
+        :shirt_received, 
+        :place_of_worship, 
+        :recruitment, 
+        :community_networks, 
+        :extra_groups, 
+        :other_networks, 
+        :graduating_class_id, 
+        :school_id, 
+        :identity_id, 
+        :high_school_gpa,
+        :organization_ids => [], 
+        :neighborhood_ids => [], 
+        :extracurricular_activity_ids => [], 
+        :talent_ids => [], 
+        :cohort_ids => []
+      )
     end
 end

--- a/app/views/members/_form.html.erb
+++ b/app/views/members/_form.html.erb
@@ -135,6 +135,16 @@
     <%= f.text_field :zip_code, class: "form-control" %>
   </div>
 </div>
+
+<h1>Student Profile</h1>
+<div class="form-group">
+  <%= f.label :high_school_gpa, class: "col-sm-2 control-label" %>
+  <div class="col-sm-10">
+    <%= f.text_field :high_school_gpa, class: "form-control" %>
+  </div>
+</div>
+
+<h1>Network Night</h1>
 <div class="form-group">
   <%= f.label :shirt_size, class: "col-sm-2 control-label" %>
   <div class="col-sm-10">

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -78,6 +78,9 @@
   <dt>Zip code:</dt>
   <dd><%= @member.zip_code %></dd>
 
+  <dt>High School GPA:</dt>
+  <dd><%= @member.high_school_gpa %></dd>
+  
   <dt>Shirt size:</dt>
   <dd><%= @member.shirt_size %></dd>
 

--- a/db/migrate/20180622145435_add_high_school_gpa_to_members.rb
+++ b/db/migrate/20180622145435_add_high_school_gpa_to_members.rb
@@ -1,0 +1,5 @@
+class AddHighSchoolGpaToMembers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :members, :high_school_gpa, :float
+  end
+end

--- a/db/migrate/20180626132026_add_high_school_gpa_to_member_dimensions.rb
+++ b/db/migrate/20180626132026_add_high_school_gpa_to_member_dimensions.rb
@@ -1,0 +1,5 @@
+class AddHighSchoolGpaToMemberDimensions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :member_dimensions, :high_school_gpa, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180529161058) do
+ActiveRecord::Schema.define(version: 2018_06_26_132026) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -178,6 +178,7 @@ ActiveRecord::Schema.define(version: 20180529161058) do
     t.string "state"
     t.string "zip"
     t.integer "member_id"
+    t.float "high_school_gpa"
   end
 
   create_table "members", force: :cascade do |t|
@@ -205,6 +206,7 @@ ActiveRecord::Schema.define(version: 20180529161058) do
     t.string "mongo_id"
     t.integer "identity_id"
     t.datetime "date_of_birth"
+    t.float "high_school_gpa"
     t.index ["identity_id"], name: "index_members_on_identity_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -81,6 +81,7 @@ victoria = Member.create(
   neighborhoods: [roebuck],
   cohorts: [gear_up],
   school: carver,
+  high_school_gpa: 4.0,
   user_id: user.id
 )
 chris = Member.create(
@@ -91,6 +92,7 @@ chris = Member.create(
   neighborhoods: [smithfield,ensley],
   cohorts: [health_academy],
   school: carver,
+  high_school_gpa: 4.0,
   user_id: user.id
 )
 andrew = Member.create(
@@ -101,6 +103,7 @@ andrew = Member.create(
   neighborhoods: [woodlawn],
   cohorts: [health_academy, gear_up],
   school: hudson,
+  high_school_gpa: 4.0,
   user_id: user.id
 )
 sean = Member.create(
@@ -111,6 +114,7 @@ sean = Member.create(
   neighborhoods: [ensley],
   cohorts: [educator_academy],
   school: ramsey,
+  high_school_gpa: 4.0,
   user_id: user.id
 )
 
@@ -142,6 +146,7 @@ student_nell = Member.create(
   school: carver,
   graduating_class: class_of_2017,
   cohorts: [gear_up],
+  high_school_gpa: 4.0,
   user_id: user.id
 )
 
@@ -244,6 +249,7 @@ identity_enumerator = Identity.all.cycle
     neighborhoods: [ensley],
     cohorts: [educator_academy],
     school: ramsey,
+    high_school_gpa: 4.0,
     user_id: user.id,
     identity: identity_enumerator.next
   )

--- a/test/controllers/members_controller_test.rb
+++ b/test/controllers/members_controller_test.rb
@@ -17,29 +17,91 @@ class MembersControllerTest < ActionController::TestCase
   test "should get new" do
     get :new
     assert_response :success
+    assert_select "input[name='member[high_school_gpa]']"
   end
 
   test "should create member" do
+    member_attributes = { 
+      address: @member.address, 
+      city: @member.city, 
+      community_networks: @member.community_networks, 
+      email: @member.email, 
+      extra_groups: @member.extra_groups, 
+      first_name: @member.first_name, 
+      identity_id: @member.identity_id, 
+      last_name: @member.last_name, 
+      other_networks: @member.other_networks, 
+      phone: @member.phone, 
+      place_of_worship: @member.place_of_worship, 
+      recruitment: @member.recruitment, 
+      shirt_received: @member.shirt_received, 
+      shirt_size: @member.shirt_size, 
+      state: @member.state, 
+      user_id: @member.user_id, 
+      zip_code: @member.zip_code,
+      high_school_gpa: @member.high_school_gpa
+    }
+    
     assert_difference('Member.count') do
-      post :create, params: { member: { address: @member.address, city: @member.city, community_networks: @member.community_networks, email: @member.email, extra_groups: @member.extra_groups, first_name: @member.first_name, identity_id: @member.identity_id, last_name: @member.last_name, other_networks: @member.other_networks, phone: @member.phone, place_of_worship: @member.place_of_worship, recruitment: @member.recruitment, shirt_received: @member.shirt_received, shirt_size: @member.shirt_size, state: @member.state, user_id: @member.user_id, zip_code: @member.zip_code } }
+      post :create, params: { 
+        member: member_attributes 
+      }
     end
 
     assert_redirected_to member_path(assigns(:member))
+    
+    member_attributes.each do |key, value|
+      assert_equal value, assigns(:member).attributes[key.to_s], 
+        "Attribute '#{key}' does not match."
+    end
   end
 
   test "should show member" do
     get :show, params: { id: @member }
     assert_response :success
+    assert_select 'dt', 'High School GPA:'
+    assert_select 'dd', @member.high_school_gpa.to_s
   end
 
   test "should get edit" do
     get :edit, params: { id: @member }
     assert_response :success
+    assert_select "input[name='member[high_school_gpa]']"
   end
 
   test "should update member" do
-    patch :update, params: { id: @member, member: { address: @member.address, city: @member.city, community_networks: @member.community_networks, email: @member.email, extra_groups: @member.extra_groups, first_name: @member.first_name, identity_id: @member.identity_id, last_name: @member.last_name, other_networks: @member.other_networks, phone: @member.phone, place_of_worship: @member.place_of_worship, recruitment: @member.recruitment, shirt_received: @member.shirt_received, shirt_size: @member.shirt_size, state: @member.state, user_id: @member.user_id, zip_code: @member.zip_code } }
+    member_attributes = { 
+      address: @member.address, 
+      city: @member.city, 
+      community_networks: @member.community_networks, 
+      email: @member.email, 
+      extra_groups: @member.extra_groups, 
+      first_name: @member.first_name, 
+      identity_id: @member.identity_id, 
+      last_name: @member.last_name, 
+      other_networks: @member.other_networks, 
+      phone: @member.phone, 
+      place_of_worship: @member.place_of_worship, 
+      recruitment: @member.recruitment, 
+      shirt_received: @member.shirt_received, 
+      shirt_size: @member.shirt_size, 
+      state: @member.state, 
+      user_id: @member.user_id, 
+      zip_code: @member.zip_code,
+      high_school_gpa: @member.high_school_gpa - 1.0
+    }
+    
+    patch :update, params: { 
+      id: @member, 
+      member: member_attributes 
+    }
+    
     assert_redirected_to member_path(assigns(:member))
+    
+    member_attributes.each do |key, value|
+      assert_equal value, assigns(:member).attributes[key.to_s], 
+        "Attribute '#{key}' does not match."
+    end
   end
 
   test "should destroy member" do

--- a/test/etl/dimensions/member_test.rb
+++ b/test/etl/dimensions/member_test.rb
@@ -10,7 +10,8 @@ class ETLDimensionsMemberTest < ActiveSupport::TestCase
           school: schools(:tuggle),
           city: 'Birmingham',
           state: 'AL',
-          zip_code: '35205'
+          zip_code: '35205',
+          high_school_gpa: 4.0
       )
       @member.save
 
@@ -58,5 +59,9 @@ class ETLDimensionsMemberTest < ActiveSupport::TestCase
 
   test 'Zip is extracted' do
       assert_equal '35205', @member_dimension.zip
+  end
+  
+  test 'High School GPA is extracted' do
+    assert_equal @member.high_school_gpa, @member_dimension.high_school_gpa
   end
 end

--- a/test/fixtures/members.yml
+++ b/test/fixtures/members.yml
@@ -20,6 +20,7 @@ one:
   school: carver
   graduating_class: class_of_2016
   identity: student
+  high_school_gpa: 4.0
 
 two:
   first_name: MyString
@@ -41,6 +42,7 @@ two:
   school: carver
   graduating_class: class_of_2017
   identity: two
+  high_school_gpa: 4.0
 
 three:
   first_name: MyString
@@ -61,36 +63,45 @@ three:
   user: three
   school: tuggle
   graduating_class: class_of_2017
+  high_school_gpa: 4.0
 
 jane:
   first_name: Jane
   last_name: Doe
+  high_school_gpa: 4.0
 
 john:
   first_name: John
   last_name: Smith
+  high_school_gpa: 4.0
 
 martin:
   first_name: Martin
   last_name: King
   graduating_class: class_of_2017
+  high_school_gpa: 4.0
 
 george:
   first_name: George
   last_name: Carver
+  high_school_gpa: 4.0
 
 rosa:
   first_name: Rosa
   last_name: Parks
+  high_school_gpa: 4.0
 
 carrie:
   first_name: Carrie
   last_name: Tuggle
+  high_school_gpa: 4.0
 
 ossie:
   first_name: Ossie
   last_name: Mitchell
+  high_school_gpa: 4.0
 
 malachi:
   first_name: Malachi
   last_name: Wilkerson
+  high_school_gpa: 4.0

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -20,4 +20,10 @@ class MemberTest < ActiveSupport::TestCase
     member = Member.new(first_name: 'First', last_name: 'Last', date_of_birth: 20.days.ago)
     assert member.save 
   end
+  
+  test 'should save member with high school gpa' do
+    member = Member.new(first_name: 'First', last_name: 'Last', high_school_gpa: 4.0)
+    assert member.save 
+  end
+    
 end


### PR DESCRIPTION
In order to have better demographics for longitudinal tracking the
student's high school GPA has been added to the member profile.  Also,
the high school GPA was added to the analytics star schema in order to
facilitate reporting.