### PR TITLE
Add ACT score to the member model

### DIFF
--- a/app/analytics/etl/dimensions/member.rb
+++ b/app/analytics/etl/dimensions/member.rb
@@ -10,7 +10,8 @@ class Etl::Dimensions::Member
                 city: member.city,
                 state: member.state,
                 zip: member.zip_code,
-                high_school_gpa: member.high_school_gpa
+                high_school_gpa: member.high_school_gpa,
+                act_score: member.act_score
             }
 
             if MemberDimension.where(member_id: attributes[:member_id]).exists?

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -177,6 +177,7 @@ class MembersController < ApplicationController
         :school_id, 
         :identity_id, 
         :high_school_gpa,
+        :act_score,
         :organization_ids => [], 
         :neighborhood_ids => [], 
         :extracurricular_activity_ids => [], 

--- a/app/views/members/_form.html.erb
+++ b/app/views/members/_form.html.erb
@@ -143,6 +143,12 @@
     <%= f.text_field :high_school_gpa, class: "form-control" %>
   </div>
 </div>
+<div class="form-group">
+  <%= f.label :act_score, class: "col-sm-2 control-label" %>
+  <div class="col-sm-10">
+    <%= f.text_field :act_score, class: "form-control" %>
+  </div>
+</div>
 
 <h1>Network Night</h1>
 <div class="form-group">

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -81,6 +81,9 @@
   <dt>High School GPA:</dt>
   <dd><%= @member.high_school_gpa %></dd>
   
+  <dt>ACT Score:</dt>
+  <dd><%= @member.act_score %></dd>
+  
   <dt>Shirt size:</dt>
   <dd><%= @member.shirt_size %></dd>
 

--- a/db/migrate/20180626142444_add_act_score_to_members.rb
+++ b/db/migrate/20180626142444_add_act_score_to_members.rb
@@ -1,0 +1,5 @@
+class AddActScoreToMembers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :members, :act_score, :integer
+  end
+end

--- a/db/migrate/20180626145142_add_act_score_to_member_dimensions.rb
+++ b/db/migrate/20180626145142_add_act_score_to_member_dimensions.rb
@@ -1,0 +1,5 @@
+class AddActScoreToMemberDimensions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :member_dimensions, :act_score, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_26_132026) do
+ActiveRecord::Schema.define(version: 2018_06_26_145142) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -179,6 +179,7 @@ ActiveRecord::Schema.define(version: 2018_06_26_132026) do
     t.string "zip"
     t.integer "member_id"
     t.float "high_school_gpa"
+    t.integer "act_score"
   end
 
   create_table "members", force: :cascade do |t|
@@ -207,6 +208,7 @@ ActiveRecord::Schema.define(version: 2018_06_26_132026) do
     t.integer "identity_id"
     t.datetime "date_of_birth"
     t.float "high_school_gpa"
+    t.integer "act_score"
     t.index ["identity_id"], name: "index_members_on_identity_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -82,6 +82,7 @@ victoria = Member.create(
   cohorts: [gear_up],
   school: carver,
   high_school_gpa: 4.0,
+  act_score: 24,
   user_id: user.id
 )
 chris = Member.create(
@@ -93,6 +94,7 @@ chris = Member.create(
   cohorts: [health_academy],
   school: carver,
   high_school_gpa: 4.0,
+  act_score: 25,
   user_id: user.id
 )
 andrew = Member.create(
@@ -104,6 +106,7 @@ andrew = Member.create(
   cohorts: [health_academy, gear_up],
   school: hudson,
   high_school_gpa: 4.0,
+  act_score: 25,
   user_id: user.id
 )
 sean = Member.create(
@@ -115,6 +118,7 @@ sean = Member.create(
   cohorts: [educator_academy],
   school: ramsey,
   high_school_gpa: 4.0,
+  act_score: 25,
   user_id: user.id
 )
 
@@ -147,6 +151,7 @@ student_nell = Member.create(
   graduating_class: class_of_2017,
   cohorts: [gear_up],
   high_school_gpa: 4.0,
+  act_score: 25,
   user_id: user.id
 )
 
@@ -250,6 +255,7 @@ identity_enumerator = Identity.all.cycle
     cohorts: [educator_academy],
     school: ramsey,
     high_school_gpa: 4.0,
+    act_score: 25,
     user_id: user.id,
     identity: identity_enumerator.next
   )

--- a/test/controllers/members_controller_test.rb
+++ b/test/controllers/members_controller_test.rb
@@ -18,6 +18,7 @@ class MembersControllerTest < ActionController::TestCase
     get :new
     assert_response :success
     assert_select "input[name='member[high_school_gpa]']"
+    assert_select "input[name='member[act_score]']"
   end
 
   test "should create member" do
@@ -39,7 +40,8 @@ class MembersControllerTest < ActionController::TestCase
       state: @member.state, 
       user_id: @member.user_id, 
       zip_code: @member.zip_code,
-      high_school_gpa: @member.high_school_gpa
+      high_school_gpa: @member.high_school_gpa,
+      act_score: @member.act_score
     }
     
     assert_difference('Member.count') do
@@ -61,12 +63,15 @@ class MembersControllerTest < ActionController::TestCase
     assert_response :success
     assert_select 'dt', 'High School GPA:'
     assert_select 'dd', @member.high_school_gpa.to_s
+    assert_select 'dt', 'ACT Score:'
+    assert_select 'dd', @member.act_score.to_s
   end
 
   test "should get edit" do
     get :edit, params: { id: @member }
     assert_response :success
     assert_select "input[name='member[high_school_gpa]']"
+    assert_select "input[name='member[act_score]']"
   end
 
   test "should update member" do
@@ -88,7 +93,8 @@ class MembersControllerTest < ActionController::TestCase
       state: @member.state, 
       user_id: @member.user_id, 
       zip_code: @member.zip_code,
-      high_school_gpa: @member.high_school_gpa - 1.0
+      high_school_gpa: @member.high_school_gpa - 1.0,
+      act_score: @member.act_score
     }
     
     patch :update, params: { 

--- a/test/etl/dimensions/member_test.rb
+++ b/test/etl/dimensions/member_test.rb
@@ -11,7 +11,8 @@ class ETLDimensionsMemberTest < ActiveSupport::TestCase
           city: 'Birmingham',
           state: 'AL',
           zip_code: '35205',
-          high_school_gpa: 4.0
+          high_school_gpa: 4.0,
+          act_score: 24
       )
       @member.save
 
@@ -63,5 +64,9 @@ class ETLDimensionsMemberTest < ActiveSupport::TestCase
   
   test 'High School GPA is extracted' do
     assert_equal @member.high_school_gpa, @member_dimension.high_school_gpa
+  end
+  
+  test 'ACT Score is extracted' do
+    assert_equal @member.act_score, @member_dimension.act_score
   end
 end

--- a/test/fixtures/members.yml
+++ b/test/fixtures/members.yml
@@ -21,6 +21,7 @@ one:
   graduating_class: class_of_2016
   identity: student
   high_school_gpa: 4.0
+  act_score: 25
 
 two:
   first_name: MyString
@@ -43,6 +44,7 @@ two:
   graduating_class: class_of_2017
   identity: two
   high_school_gpa: 4.0
+  act_score: 25
 
 three:
   first_name: MyString
@@ -69,39 +71,47 @@ jane:
   first_name: Jane
   last_name: Doe
   high_school_gpa: 4.0
+  act_score: 25
 
 john:
   first_name: John
   last_name: Smith
   high_school_gpa: 4.0
+  act_score: 25
 
 martin:
   first_name: Martin
   last_name: King
   graduating_class: class_of_2017
   high_school_gpa: 4.0
+  act_score: 25
 
 george:
   first_name: George
   last_name: Carver
   high_school_gpa: 4.0
+  act_score: 25
 
 rosa:
   first_name: Rosa
   last_name: Parks
   high_school_gpa: 4.0
+  act_score: 25
 
 carrie:
   first_name: Carrie
   last_name: Tuggle
   high_school_gpa: 4.0
+  act_score: 25
 
 ossie:
   first_name: Ossie
   last_name: Mitchell
   high_school_gpa: 4.0
+  act_score: 25
 
 malachi:
   first_name: Malachi
   last_name: Wilkerson
   high_school_gpa: 4.0
+  act_score: 25

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -25,5 +25,10 @@ class MemberTest < ActiveSupport::TestCase
     member = Member.new(first_name: 'First', last_name: 'Last', high_school_gpa: 4.0)
     assert member.save 
   end
+  
+  test 'should save member with ACT score' do
+    member = Member.new(first_name: 'First', last_name: 'Last', act_score: 25)
+    assert member.save 
+  end
     
 end


### PR DESCRIPTION
In order to have better demographics for longitudinal tracking the
student's ACT score has been added to the member profile.
Also, the ACT score was added to the analytics star schema in order
to facilitate reporting.