### PR TITLE
Add relative phone number to the member model

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -178,6 +178,7 @@ class MembersController < ApplicationController
         :identity_id, 
         :high_school_gpa,
         :act_score,
+        :relative_phone,
         :organization_ids => [], 
         :neighborhood_ids => [], 
         :extracurricular_activity_ids => [], 

--- a/app/views/members/_form.html.erb
+++ b/app/views/members/_form.html.erb
@@ -149,6 +149,12 @@
     <%= f.text_field :act_score, class: "form-control" %>
   </div>
 </div>
+<div class="form-group">
+  <%= f.label :relative_phone, class: "col-sm-2 control-label" %>
+  <div class="col-sm-10">
+    <%= f.telephone_field :relative_phone, class: "form-control" %>
+  </div>
+</div>
 
 <h1>Network Night</h1>
 <div class="form-group">

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -77,13 +77,22 @@
 
   <dt>Zip code:</dt>
   <dd><%= @member.zip_code %></dd>
+</dl>
 
+<h1>Student Profile</h1>
+<dl class="dl-horizontal text-left">
   <dt>High School GPA:</dt>
   <dd><%= @member.high_school_gpa %></dd>
   
   <dt>ACT Score:</dt>
   <dd><%= @member.act_score %></dd>
   
+  <dt>Relative Phone:</dt>
+  <dd><%= @member.relative_phone %></dd>
+</dl>
+
+<h1>Network Night</h1>
+<dl class="dl-horizontal text-left">
   <dt>Shirt size:</dt>
   <dd><%= @member.shirt_size %></dd>
 

--- a/db/migrate/20180627130608_add_relative_phone_to_member.rb
+++ b/db/migrate/20180627130608_add_relative_phone_to_member.rb
@@ -1,0 +1,5 @@
+class AddRelativePhoneToMember < ActiveRecord::Migration[5.2]
+  def change
+    add_column :members, :relative_phone, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_26_145142) do
+ActiveRecord::Schema.define(version: 2018_06_27_130608) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -209,6 +209,7 @@ ActiveRecord::Schema.define(version: 2018_06_26_145142) do
     t.datetime "date_of_birth"
     t.float "high_school_gpa"
     t.integer "act_score"
+    t.string "relative_phone"
     t.index ["identity_id"], name: "index_members_on_identity_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -83,6 +83,7 @@ victoria = Member.create(
   school: carver,
   high_school_gpa: 4.0,
   act_score: 24,
+  relative_phone: '2056683333',
   user_id: user.id
 )
 chris = Member.create(
@@ -95,6 +96,7 @@ chris = Member.create(
   school: carver,
   high_school_gpa: 4.0,
   act_score: 25,
+  relative_phone: '2056683333',
   user_id: user.id
 )
 andrew = Member.create(
@@ -107,6 +109,7 @@ andrew = Member.create(
   school: hudson,
   high_school_gpa: 4.0,
   act_score: 25,
+  relative_phone: '2056683333',
   user_id: user.id
 )
 sean = Member.create(
@@ -119,6 +122,7 @@ sean = Member.create(
   school: ramsey,
   high_school_gpa: 4.0,
   act_score: 25,
+  relative_phone: '2056683333',
   user_id: user.id
 )
 
@@ -152,6 +156,7 @@ student_nell = Member.create(
   cohorts: [gear_up],
   high_school_gpa: 4.0,
   act_score: 25,
+  relative_phone: '2056683333',
   user_id: user.id
 )
 
@@ -256,6 +261,7 @@ identity_enumerator = Identity.all.cycle
     school: ramsey,
     high_school_gpa: 4.0,
     act_score: 25,
+    relative_phone: '2056683333',
     user_id: user.id,
     identity: identity_enumerator.next
   )

--- a/test/controllers/members_controller_test.rb
+++ b/test/controllers/members_controller_test.rb
@@ -19,6 +19,7 @@ class MembersControllerTest < ActionController::TestCase
     assert_response :success
     assert_select "input[name='member[high_school_gpa]']"
     assert_select "input[name='member[act_score]']"
+    assert_select "input[name='member[relative_phone]']"
   end
 
   test "should create member" do
@@ -41,7 +42,8 @@ class MembersControllerTest < ActionController::TestCase
       user_id: @member.user_id, 
       zip_code: @member.zip_code,
       high_school_gpa: @member.high_school_gpa,
-      act_score: @member.act_score
+      act_score: @member.act_score,
+      relative_phone: @member.relative_phone
     }
     
     assert_difference('Member.count') do
@@ -65,6 +67,8 @@ class MembersControllerTest < ActionController::TestCase
     assert_select 'dd', @member.high_school_gpa.to_s
     assert_select 'dt', 'ACT Score:'
     assert_select 'dd', @member.act_score.to_s
+    assert_select 'dt', 'Relative Phone:'
+    assert_select 'dd', @member.relative_phone.to_s
   end
 
   test "should get edit" do
@@ -72,6 +76,7 @@ class MembersControllerTest < ActionController::TestCase
     assert_response :success
     assert_select "input[name='member[high_school_gpa]']"
     assert_select "input[name='member[act_score]']"
+    assert_select "input[name='member[relative_phone]']"
   end
 
   test "should update member" do
@@ -94,7 +99,8 @@ class MembersControllerTest < ActionController::TestCase
       user_id: @member.user_id, 
       zip_code: @member.zip_code,
       high_school_gpa: @member.high_school_gpa - 1.0,
-      act_score: @member.act_score
+      act_score: @member.act_score,
+      relative_phone: @member.relative_phone
     }
     
     patch :update, params: { 

--- a/test/fixtures/members.yml
+++ b/test/fixtures/members.yml
@@ -22,6 +22,7 @@ one:
   identity: student
   high_school_gpa: 4.0
   act_score: 25
+  relative_phone: 2056687777
 
 two:
   first_name: MyString
@@ -45,6 +46,7 @@ two:
   identity: two
   high_school_gpa: 4.0
   act_score: 25
+  relative_phone: 2056687777
 
 three:
   first_name: MyString
@@ -72,12 +74,14 @@ jane:
   last_name: Doe
   high_school_gpa: 4.0
   act_score: 25
+  relative_phone: 2056687777
 
 john:
   first_name: John
   last_name: Smith
   high_school_gpa: 4.0
   act_score: 25
+  relative_phone: 2056687777
 
 martin:
   first_name: Martin
@@ -85,33 +89,39 @@ martin:
   graduating_class: class_of_2017
   high_school_gpa: 4.0
   act_score: 25
+  relative_phone: 2056687777
 
 george:
   first_name: George
   last_name: Carver
   high_school_gpa: 4.0
   act_score: 25
+  relative_phone: 2056687777
 
 rosa:
   first_name: Rosa
   last_name: Parks
   high_school_gpa: 4.0
   act_score: 25
+  relative_phone: 2056687777
 
 carrie:
   first_name: Carrie
   last_name: Tuggle
   high_school_gpa: 4.0
   act_score: 25
+  relative_phone: 2056687777
 
 ossie:
   first_name: Ossie
   last_name: Mitchell
   high_school_gpa: 4.0
   act_score: 25
+  relative_phone: 2056687777
 
 malachi:
   first_name: Malachi
   last_name: Wilkerson
   high_school_gpa: 4.0
   act_score: 25
+  relative_phone: 2056687777

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -30,5 +30,10 @@ class MemberTest < ActiveSupport::TestCase
     member = Member.new(first_name: 'First', last_name: 'Last', act_score: 25)
     assert member.save 
   end
+  
+  test 'should save member with relative phone number' do
+    member = Member.new(first_name: 'First', last_name: 'Last', relative_phone: '2055869999')
+    assert member.save 
+  end
     
 end


### PR DESCRIPTION
In order to have better contacit information to followup with
student's for longitudinal tracking, a relative phone number has
been added to the member profile.