### PR TITLE
Add relative email address to the member model

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -179,6 +179,7 @@ class MembersController < ApplicationController
         :high_school_gpa,
         :act_score,
         :relative_phone,
+        :relative_email,
         :organization_ids => [], 
         :neighborhood_ids => [], 
         :extracurricular_activity_ids => [], 

--- a/app/views/members/_form.html.erb
+++ b/app/views/members/_form.html.erb
@@ -155,6 +155,12 @@
     <%= f.telephone_field :relative_phone, class: "form-control" %>
   </div>
 </div>
+<div class="form-group">
+  <%= f.label :relative_email, class: "col-sm-2 control-label" %>
+  <div class="col-sm-10">
+    <%= f.email_field :relative_email, class: "form-control" %>
+  </div>
+</div>
 
 <h1>Network Night</h1>
 <div class="form-group">

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -89,6 +89,9 @@
   
   <dt>Relative Phone:</dt>
   <dd><%= @member.relative_phone %></dd>
+  
+  <dt>Relative Email:</dt>
+  <dd><%= @member.relative_email %></dd>
 </dl>
 
 <h1>Network Night</h1>

--- a/db/migrate/20180627140515_add_relative_email_to_members.rb
+++ b/db/migrate/20180627140515_add_relative_email_to_members.rb
@@ -1,0 +1,5 @@
+class AddRelativeEmailToMembers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :members, :relative_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_27_130608) do
+ActiveRecord::Schema.define(version: 2018_06_27_140515) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -210,6 +210,7 @@ ActiveRecord::Schema.define(version: 2018_06_27_130608) do
     t.float "high_school_gpa"
     t.integer "act_score"
     t.string "relative_phone"
+    t.string "relative_email"
     t.index ["identity_id"], name: "index_members_on_identity_id"
   end
 

--- a/test/controllers/members_controller_test.rb
+++ b/test/controllers/members_controller_test.rb
@@ -20,6 +20,7 @@ class MembersControllerTest < ActionController::TestCase
     assert_select "input[name='member[high_school_gpa]']"
     assert_select "input[name='member[act_score]']"
     assert_select "input[name='member[relative_phone]']"
+    assert_select "input[name='member[relative_email]']"
   end
 
   test "should create member" do
@@ -43,7 +44,8 @@ class MembersControllerTest < ActionController::TestCase
       zip_code: @member.zip_code,
       high_school_gpa: @member.high_school_gpa,
       act_score: @member.act_score,
-      relative_phone: @member.relative_phone
+      relative_phone: @member.relative_phone,
+      relative_email: @member.relative_email
     }
     
     assert_difference('Member.count') do
@@ -69,6 +71,8 @@ class MembersControllerTest < ActionController::TestCase
     assert_select 'dd', @member.act_score.to_s
     assert_select 'dt', 'Relative Phone:'
     assert_select 'dd', @member.relative_phone.to_s
+    assert_select 'dt', 'Relative Email:'
+    assert_select 'dd', @member.relative_email.to_s
   end
 
   test "should get edit" do
@@ -77,6 +81,7 @@ class MembersControllerTest < ActionController::TestCase
     assert_select "input[name='member[high_school_gpa]']"
     assert_select "input[name='member[act_score]']"
     assert_select "input[name='member[relative_phone]']"
+    assert_select "input[name='member[relative_email]']"
   end
 
   test "should update member" do
@@ -100,7 +105,8 @@ class MembersControllerTest < ActionController::TestCase
       zip_code: @member.zip_code,
       high_school_gpa: @member.high_school_gpa - 1.0,
       act_score: @member.act_score,
-      relative_phone: @member.relative_phone
+      relative_phone: @member.relative_phone,
+      relative_email: @member.relative_email
     }
     
     patch :update, params: { 

--- a/test/fixtures/members.yml
+++ b/test/fixtures/members.yml
@@ -23,6 +23,7 @@ one:
   high_school_gpa: 4.0
   act_score: 25
   relative_phone: 2056687777
+  relative_email: relative@example.com
 
 two:
   first_name: MyString
@@ -47,6 +48,7 @@ two:
   high_school_gpa: 4.0
   act_score: 25
   relative_phone: 2056687777
+  relative_email: relative@example.com
 
 three:
   first_name: MyString
@@ -75,6 +77,7 @@ jane:
   high_school_gpa: 4.0
   act_score: 25
   relative_phone: 2056687777
+  relative_email: relative@example.com
 
 john:
   first_name: John
@@ -82,6 +85,7 @@ john:
   high_school_gpa: 4.0
   act_score: 25
   relative_phone: 2056687777
+  relative_email: relative@example.com
 
 martin:
   first_name: Martin
@@ -90,6 +94,7 @@ martin:
   high_school_gpa: 4.0
   act_score: 25
   relative_phone: 2056687777
+  relative_email: relative@example.com
 
 george:
   first_name: George
@@ -97,6 +102,7 @@ george:
   high_school_gpa: 4.0
   act_score: 25
   relative_phone: 2056687777
+  relative_email: relative@example.com
 
 rosa:
   first_name: Rosa
@@ -104,6 +110,7 @@ rosa:
   high_school_gpa: 4.0
   act_score: 25
   relative_phone: 2056687777
+  relative_email: relative@example.com
 
 carrie:
   first_name: Carrie
@@ -111,6 +118,7 @@ carrie:
   high_school_gpa: 4.0
   act_score: 25
   relative_phone: 2056687777
+  relative_email: relative@example.com
 
 ossie:
   first_name: Ossie
@@ -118,6 +126,7 @@ ossie:
   high_school_gpa: 4.0
   act_score: 25
   relative_phone: 2056687777
+  relative_email: relative@example.com
 
 malachi:
   first_name: Malachi
@@ -125,3 +134,4 @@ malachi:
   high_school_gpa: 4.0
   act_score: 25
   relative_phone: 2056687777
+  relative_email: relative@example.com

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -35,5 +35,10 @@ class MemberTest < ActiveSupport::TestCase
     member = Member.new(first_name: 'First', last_name: 'Last', relative_phone: '2055869999')
     assert member.save 
   end
+  
+  test 'should save member with relative email address' do
+    member = Member.new(first_name: 'First', last_name: 'Last', relative_email: 'relative@example.com')
+    assert member.save 
+  end
     
 end


### PR DESCRIPTION
In order to have better contact information to followup with
student's for longitudinal tracking, a relative email address has
been added to the member profile.