### PR TITLE
Add facebook name to the member model

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -180,6 +180,7 @@ class MembersController < ApplicationController
         :act_score,
         :relative_phone,
         :relative_email,
+        :facebook_name,
         :organization_ids => [], 
         :neighborhood_ids => [], 
         :extracurricular_activity_ids => [], 

--- a/app/views/members/_form.html.erb
+++ b/app/views/members/_form.html.erb
@@ -42,6 +42,12 @@
   </div>
 </div>
 <div class="form-group">
+  <%= f.label :facebook_name, class: "col-sm-2 control-label" %>
+  <div class="col-sm-10">
+    <%= f.text_field :facebook_name, class: "form-control" %>
+  </div>
+</div>
+<div class="form-group">
   <%= f.label :identity_id, class: "col-sm-2 control-label" %>
   <div class="col-sm-10">
     <%= f.collection_select(

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -30,6 +30,9 @@
   <dt>Email:</dt>
   <dd><%= mail_to @member.email %></dd>
 
+  <dt>Facebook Name:</dt>
+  <dd><%= @member.facebook_name %></dd>
+  
   <dt>Identity:</dt>
   <dd><%= @member.identity.try(:name) %></dd>
   

--- a/db/migrate/20180627143739_add_facebook_name_to_members.rb
+++ b/db/migrate/20180627143739_add_facebook_name_to_members.rb
@@ -1,0 +1,5 @@
+class AddFacebookNameToMembers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :members, :facebook_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_27_140515) do
+ActiveRecord::Schema.define(version: 2018_06_27_143739) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -211,6 +211,7 @@ ActiveRecord::Schema.define(version: 2018_06_27_140515) do
     t.integer "act_score"
     t.string "relative_phone"
     t.string "relative_email"
+    t.string "facebook_name"
     t.index ["identity_id"], name: "index_members_on_identity_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -84,6 +84,8 @@ victoria = Member.create(
   high_school_gpa: 4.0,
   act_score: 24,
   relative_phone: '2056683333',
+  relative_email: 'relative@example.com',
+  facebook_name: 'facebookname',
   user_id: user.id
 )
 chris = Member.create(
@@ -97,6 +99,8 @@ chris = Member.create(
   high_school_gpa: 4.0,
   act_score: 25,
   relative_phone: '2056683333',
+  relative_email: 'relative@example.com',
+  facebook_name: 'facebookname',
   user_id: user.id
 )
 andrew = Member.create(
@@ -110,6 +114,8 @@ andrew = Member.create(
   high_school_gpa: 4.0,
   act_score: 25,
   relative_phone: '2056683333',
+  relative_email: 'relative@example.com',
+  facebook_name: 'facebookname',
   user_id: user.id
 )
 sean = Member.create(
@@ -123,6 +129,8 @@ sean = Member.create(
   high_school_gpa: 4.0,
   act_score: 25,
   relative_phone: '2056683333',
+  relative_email: 'relative@example.com',
+  facebook_name: 'facebookname',
   user_id: user.id
 )
 
@@ -157,6 +165,8 @@ student_nell = Member.create(
   high_school_gpa: 4.0,
   act_score: 25,
   relative_phone: '2056683333',
+  relative_email: 'relative@example.com',
+  facebook_name: 'facebookname',
   user_id: user.id
 )
 
@@ -262,6 +272,8 @@ identity_enumerator = Identity.all.cycle
     high_school_gpa: 4.0,
     act_score: 25,
     relative_phone: '2056683333',
+    relative_email: 'relative@example.com',
+    facebook_name: 'facebookname',
     user_id: user.id,
     identity: identity_enumerator.next
   )

--- a/test/controllers/members_controller_test.rb
+++ b/test/controllers/members_controller_test.rb
@@ -21,6 +21,7 @@ class MembersControllerTest < ActionController::TestCase
     assert_select "input[name='member[act_score]']"
     assert_select "input[name='member[relative_phone]']"
     assert_select "input[name='member[relative_email]']"
+    assert_select "input[name='member[facebook_name]']"
   end
 
   test "should create member" do
@@ -45,7 +46,8 @@ class MembersControllerTest < ActionController::TestCase
       high_school_gpa: @member.high_school_gpa,
       act_score: @member.act_score,
       relative_phone: @member.relative_phone,
-      relative_email: @member.relative_email
+      relative_email: @member.relative_email,
+      facebook_name: @member.facebook_name
     }
     
     assert_difference('Member.count') do
@@ -73,6 +75,8 @@ class MembersControllerTest < ActionController::TestCase
     assert_select 'dd', @member.relative_phone.to_s
     assert_select 'dt', 'Relative Email:'
     assert_select 'dd', @member.relative_email.to_s
+    assert_select 'dt', 'Facebook Name:'
+    assert_select 'dd', @member.facebook_name.to_s
   end
 
   test "should get edit" do
@@ -82,6 +86,7 @@ class MembersControllerTest < ActionController::TestCase
     assert_select "input[name='member[act_score]']"
     assert_select "input[name='member[relative_phone]']"
     assert_select "input[name='member[relative_email]']"
+    assert_select "input[name='member[facebook_name]']"
   end
 
   test "should update member" do
@@ -104,9 +109,10 @@ class MembersControllerTest < ActionController::TestCase
       user_id: @member.user_id, 
       zip_code: @member.zip_code,
       high_school_gpa: @member.high_school_gpa - 1.0,
-      act_score: @member.act_score,
-      relative_phone: @member.relative_phone,
-      relative_email: @member.relative_email
+      act_score: @member.act_score - 1,
+      relative_phone: 'change.' + @member.relative_phone,
+      relative_email: 'change.' + @member.relative_email,
+      facebook_name: 'change' + @member.facebook_name
     }
     
     patch :update, params: { 

--- a/test/fixtures/members.yml
+++ b/test/fixtures/members.yml
@@ -24,6 +24,7 @@ one:
   act_score: 25
   relative_phone: 2056687777
   relative_email: relative@example.com
+  facebook_name: facebookname
 
 two:
   first_name: MyString
@@ -49,6 +50,7 @@ two:
   act_score: 25
   relative_phone: 2056687777
   relative_email: relative@example.com
+  facebook_name: facebookname
 
 three:
   first_name: MyString
@@ -78,6 +80,7 @@ jane:
   act_score: 25
   relative_phone: 2056687777
   relative_email: relative@example.com
+  facebook_name: facebookname
 
 john:
   first_name: John
@@ -86,6 +89,7 @@ john:
   act_score: 25
   relative_phone: 2056687777
   relative_email: relative@example.com
+  facebook_name: facebookname
 
 martin:
   first_name: Martin
@@ -95,6 +99,7 @@ martin:
   act_score: 25
   relative_phone: 2056687777
   relative_email: relative@example.com
+  facebook_name: facebookname
 
 george:
   first_name: George
@@ -103,6 +108,7 @@ george:
   act_score: 25
   relative_phone: 2056687777
   relative_email: relative@example.com
+  facebook_name: facebookname
 
 rosa:
   first_name: Rosa
@@ -111,6 +117,7 @@ rosa:
   act_score: 25
   relative_phone: 2056687777
   relative_email: relative@example.com
+  facebook_name: facebookname
 
 carrie:
   first_name: Carrie
@@ -119,6 +126,7 @@ carrie:
   act_score: 25
   relative_phone: 2056687777
   relative_email: relative@example.com
+  facebook_name: facebookname
 
 ossie:
   first_name: Ossie
@@ -127,6 +135,7 @@ ossie:
   act_score: 25
   relative_phone: 2056687777
   relative_email: relative@example.com
+  facebook_name: facebookname
 
 malachi:
   first_name: Malachi
@@ -135,3 +144,4 @@ malachi:
   act_score: 25
   relative_phone: 2056687777
   relative_email: relative@example.com
+  facebook_name: facebookname

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -40,5 +40,10 @@ class MemberTest < ActiveSupport::TestCase
     member = Member.new(first_name: 'First', last_name: 'Last', relative_email: 'relative@example.com')
     assert member.save 
   end
+  
+  test 'should save member with facebook name' do
+    member = Member.new(first_name: 'First', last_name: 'Last', facebook_name: 'facebookname')
+    assert member.save 
+  end
     
 end


### PR DESCRIPTION
In order to have better contact information to followup with
student's for longitudinal tracking, a facebook name field has
been added to the member profile.