### PR TITLE
Add twitter handle to the member model

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -181,6 +181,7 @@ class MembersController < ApplicationController
         :relative_phone,
         :relative_email,
         :facebook_name,
+        :twitter_handle,
         :organization_ids => [], 
         :neighborhood_ids => [], 
         :extracurricular_activity_ids => [], 

--- a/app/views/members/_form.html.erb
+++ b/app/views/members/_form.html.erb
@@ -48,6 +48,12 @@
   </div>
 </div>
 <div class="form-group">
+  <%= f.label :twitter_handle, class: "col-sm-2 control-label" %>
+  <div class="col-sm-10">
+    <%= f.text_field :twitter_handle, class: "form-control" %>
+  </div>
+</div>
+<div class="form-group">
   <%= f.label :identity_id, class: "col-sm-2 control-label" %>
   <div class="col-sm-10">
     <%= f.collection_select(

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -33,6 +33,9 @@
   <dt>Facebook Name:</dt>
   <dd><%= @member.facebook_name %></dd>
   
+  <dt>Twitter Handle:</dt>
+  <dd><%= @member.twitter_handle %></dd>
+  
   <dt>Identity:</dt>
   <dd><%= @member.identity.try(:name) %></dd>
   

--- a/db/migrate/20180628134259_add_twitter_handle_to_members.rb
+++ b/db/migrate/20180628134259_add_twitter_handle_to_members.rb
@@ -1,0 +1,5 @@
+class AddTwitterHandleToMembers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :members, :twitter_handle, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_27_143739) do
+ActiveRecord::Schema.define(version: 2018_06_28_134259) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -212,6 +212,7 @@ ActiveRecord::Schema.define(version: 2018_06_27_143739) do
     t.string "relative_phone"
     t.string "relative_email"
     t.string "facebook_name"
+    t.string "twitter_handle"
     t.index ["identity_id"], name: "index_members_on_identity_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -86,6 +86,7 @@ victoria = Member.create(
   relative_phone: '2056683333',
   relative_email: 'relative@example.com',
   facebook_name: 'facebookname',
+  twitter_handle: 'twitterhandle',
   user_id: user.id
 )
 chris = Member.create(
@@ -101,6 +102,7 @@ chris = Member.create(
   relative_phone: '2056683333',
   relative_email: 'relative@example.com',
   facebook_name: 'facebookname',
+  twitter_handle: 'twitterhandle',
   user_id: user.id
 )
 andrew = Member.create(
@@ -116,6 +118,7 @@ andrew = Member.create(
   relative_phone: '2056683333',
   relative_email: 'relative@example.com',
   facebook_name: 'facebookname',
+  twitter_handle: 'twitterhandle',
   user_id: user.id
 )
 sean = Member.create(
@@ -131,6 +134,7 @@ sean = Member.create(
   relative_phone: '2056683333',
   relative_email: 'relative@example.com',
   facebook_name: 'facebookname',
+  twitter_handle: 'twitterhandle',
   user_id: user.id
 )
 
@@ -167,6 +171,7 @@ student_nell = Member.create(
   relative_phone: '2056683333',
   relative_email: 'relative@example.com',
   facebook_name: 'facebookname',
+  twitter_handle: 'twitterhandle',
   user_id: user.id
 )
 
@@ -274,6 +279,7 @@ identity_enumerator = Identity.all.cycle
     relative_phone: '2056683333',
     relative_email: 'relative@example.com',
     facebook_name: 'facebookname',
+    twitter_handle: 'twitterhandle',
     user_id: user.id,
     identity: identity_enumerator.next
   )

--- a/test/controllers/members_controller_test.rb
+++ b/test/controllers/members_controller_test.rb
@@ -22,6 +22,7 @@ class MembersControllerTest < ActionController::TestCase
     assert_select "input[name='member[relative_phone]']"
     assert_select "input[name='member[relative_email]']"
     assert_select "input[name='member[facebook_name]']"
+    assert_select "input[name='member[twitter_handle]']"
   end
 
   test "should create member" do
@@ -47,7 +48,8 @@ class MembersControllerTest < ActionController::TestCase
       act_score: @member.act_score,
       relative_phone: @member.relative_phone,
       relative_email: @member.relative_email,
-      facebook_name: @member.facebook_name
+      facebook_name: @member.facebook_name,
+      twitter_handle: @member.twitter_handle
     }
     
     assert_difference('Member.count') do
@@ -72,11 +74,13 @@ class MembersControllerTest < ActionController::TestCase
     assert_select 'dt', 'ACT Score:'
     assert_select 'dd', @member.act_score.to_s
     assert_select 'dt', 'Relative Phone:'
-    assert_select 'dd', @member.relative_phone.to_s
+    assert_select 'dd', @member.relative_phone
     assert_select 'dt', 'Relative Email:'
-    assert_select 'dd', @member.relative_email.to_s
+    assert_select 'dd', @member.relative_email
     assert_select 'dt', 'Facebook Name:'
-    assert_select 'dd', @member.facebook_name.to_s
+    assert_select 'dd', @member.facebook_name
+    assert_select 'dt', 'Twitter Handle:'
+    assert_select 'dd', @member.twitter_handle
   end
 
   test "should get edit" do
@@ -87,6 +91,7 @@ class MembersControllerTest < ActionController::TestCase
     assert_select "input[name='member[relative_phone]']"
     assert_select "input[name='member[relative_email]']"
     assert_select "input[name='member[facebook_name]']"
+    assert_select "input[name='member[twitter_handle]']"
   end
 
   test "should update member" do
@@ -112,7 +117,8 @@ class MembersControllerTest < ActionController::TestCase
       act_score: @member.act_score - 1,
       relative_phone: 'change.' + @member.relative_phone,
       relative_email: 'change.' + @member.relative_email,
-      facebook_name: 'change' + @member.facebook_name
+      facebook_name: 'change' + @member.facebook_name,
+      twitter_handle: 'change' + @member.twitter_handle
     }
     
     patch :update, params: { 

--- a/test/fixtures/members.yml
+++ b/test/fixtures/members.yml
@@ -25,6 +25,7 @@ one:
   relative_phone: 2056687777
   relative_email: relative@example.com
   facebook_name: facebookname
+  twitter_handle: twitterhandle
 
 two:
   first_name: MyString
@@ -51,6 +52,7 @@ two:
   relative_phone: 2056687777
   relative_email: relative@example.com
   facebook_name: facebookname
+  twitter_handle: twitterhandle
 
 three:
   first_name: MyString
@@ -81,6 +83,7 @@ jane:
   relative_phone: 2056687777
   relative_email: relative@example.com
   facebook_name: facebookname
+  twitter_handle: twitterhandle
 
 john:
   first_name: John
@@ -90,6 +93,7 @@ john:
   relative_phone: 2056687777
   relative_email: relative@example.com
   facebook_name: facebookname
+  twitter_handle: twitterhandle
 
 martin:
   first_name: Martin
@@ -100,6 +104,7 @@ martin:
   relative_phone: 2056687777
   relative_email: relative@example.com
   facebook_name: facebookname
+  twitter_handle: twitterhandle
 
 george:
   first_name: George
@@ -109,6 +114,7 @@ george:
   relative_phone: 2056687777
   relative_email: relative@example.com
   facebook_name: facebookname
+  twitter_handle: twitterhandle
 
 rosa:
   first_name: Rosa
@@ -118,6 +124,7 @@ rosa:
   relative_phone: 2056687777
   relative_email: relative@example.com
   facebook_name: facebookname
+  twitter_handle: twitterhandle
 
 carrie:
   first_name: Carrie
@@ -127,6 +134,7 @@ carrie:
   relative_phone: 2056687777
   relative_email: relative@example.com
   facebook_name: facebookname
+  twitter_handle: twitterhandle
 
 ossie:
   first_name: Ossie
@@ -136,6 +144,7 @@ ossie:
   relative_phone: 2056687777
   relative_email: relative@example.com
   facebook_name: facebookname
+  twitter_handle: twitterhandle
 
 malachi:
   first_name: Malachi
@@ -145,3 +154,4 @@ malachi:
   relative_phone: 2056687777
   relative_email: relative@example.com
   facebook_name: facebookname
+  twitter_handle: twitterhandle

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -45,5 +45,10 @@ class MemberTest < ActiveSupport::TestCase
     member = Member.new(first_name: 'First', last_name: 'Last', facebook_name: 'facebookname')
     assert member.save 
   end
+  
+  test 'should save member with twitter handle' do
+    member = Member.new(first_name: 'First', last_name: 'Last', twitter_handle: 'twitterhandle')
+    assert member.save 
+  end
     
 end


### PR DESCRIPTION
In order to have better contact information to followup with
student's for longitudinal tracking, a twitter handle field has
been added to the member profile.