### PR TITLE
Add instagram handle to the member model

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -182,6 +182,7 @@ class MembersController < ApplicationController
         :relative_email,
         :facebook_name,
         :twitter_handle,
+        :instagram_handle,
         :organization_ids => [], 
         :neighborhood_ids => [], 
         :extracurricular_activity_ids => [], 

--- a/app/views/members/_form.html.erb
+++ b/app/views/members/_form.html.erb
@@ -54,6 +54,12 @@
   </div>
 </div>
 <div class="form-group">
+  <%= f.label :instagram_handle, class: "col-sm-2 control-label" %>
+  <div class="col-sm-10">
+    <%= f.text_field :instagram_handle, class: "form-control" %>
+  </div>
+</div>
+<div class="form-group">
   <%= f.label :identity_id, class: "col-sm-2 control-label" %>
   <div class="col-sm-10">
     <%= f.collection_select(

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -36,6 +36,9 @@
   <dt>Twitter Handle:</dt>
   <dd><%= @member.twitter_handle %></dd>
   
+  <dt>Instagram Handle:</dt>
+  <dd><%= @member.instagram_handle %></dd>
+  
   <dt>Identity:</dt>
   <dd><%= @member.identity.try(:name) %></dd>
   

--- a/db/migrate/20180628142724_add_instagram_handle_to_members.rb
+++ b/db/migrate/20180628142724_add_instagram_handle_to_members.rb
@@ -1,0 +1,5 @@
+class AddInstagramHandleToMembers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :members, :instagram_handle, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_28_134259) do
+ActiveRecord::Schema.define(version: 2018_06_28_142724) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -213,6 +213,7 @@ ActiveRecord::Schema.define(version: 2018_06_28_134259) do
     t.string "relative_email"
     t.string "facebook_name"
     t.string "twitter_handle"
+    t.string "instagram_handle"
     t.index ["identity_id"], name: "index_members_on_identity_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -87,6 +87,7 @@ victoria = Member.create(
   relative_email: 'relative@example.com',
   facebook_name: 'facebookname',
   twitter_handle: 'twitterhandle',
+  instagram_handle: 'instagramhandle',
   user_id: user.id
 )
 chris = Member.create(
@@ -103,6 +104,7 @@ chris = Member.create(
   relative_email: 'relative@example.com',
   facebook_name: 'facebookname',
   twitter_handle: 'twitterhandle',
+  instagram_handle: 'instagramhandle',
   user_id: user.id
 )
 andrew = Member.create(
@@ -119,6 +121,7 @@ andrew = Member.create(
   relative_email: 'relative@example.com',
   facebook_name: 'facebookname',
   twitter_handle: 'twitterhandle',
+  instagram_handle: 'instagramhandle',
   user_id: user.id
 )
 sean = Member.create(
@@ -135,6 +138,7 @@ sean = Member.create(
   relative_email: 'relative@example.com',
   facebook_name: 'facebookname',
   twitter_handle: 'twitterhandle',
+  instagram_handle: 'instagramhandle',
   user_id: user.id
 )
 
@@ -172,6 +176,7 @@ student_nell = Member.create(
   relative_email: 'relative@example.com',
   facebook_name: 'facebookname',
   twitter_handle: 'twitterhandle',
+  instagram_handle: 'instagramhandle',
   user_id: user.id
 )
 
@@ -280,6 +285,7 @@ identity_enumerator = Identity.all.cycle
     relative_email: 'relative@example.com',
     facebook_name: 'facebookname',
     twitter_handle: 'twitterhandle',
+    instagram_handle: 'instagramhandle',
     user_id: user.id,
     identity: identity_enumerator.next
   )

--- a/test/controllers/members_controller_test.rb
+++ b/test/controllers/members_controller_test.rb
@@ -23,6 +23,7 @@ class MembersControllerTest < ActionController::TestCase
     assert_select "input[name='member[relative_email]']"
     assert_select "input[name='member[facebook_name]']"
     assert_select "input[name='member[twitter_handle]']"
+    assert_select "input[name='member[instagram_handle]']"
   end
 
   test "should create member" do
@@ -49,7 +50,8 @@ class MembersControllerTest < ActionController::TestCase
       relative_phone: @member.relative_phone,
       relative_email: @member.relative_email,
       facebook_name: @member.facebook_name,
-      twitter_handle: @member.twitter_handle
+      twitter_handle: @member.twitter_handle,
+      instagram_handle: @member.instagram_handle
     }
     
     assert_difference('Member.count') do
@@ -81,6 +83,8 @@ class MembersControllerTest < ActionController::TestCase
     assert_select 'dd', @member.facebook_name
     assert_select 'dt', 'Twitter Handle:'
     assert_select 'dd', @member.twitter_handle
+    assert_select 'dt', 'Instagram Handle:'
+    assert_select 'dd', @member.instagram_handle
   end
 
   test "should get edit" do
@@ -92,6 +96,7 @@ class MembersControllerTest < ActionController::TestCase
     assert_select "input[name='member[relative_email]']"
     assert_select "input[name='member[facebook_name]']"
     assert_select "input[name='member[twitter_handle]']"
+    assert_select "input[name='member[instagram_handle]']"
   end
 
   test "should update member" do
@@ -118,7 +123,8 @@ class MembersControllerTest < ActionController::TestCase
       relative_phone: 'change.' + @member.relative_phone,
       relative_email: 'change.' + @member.relative_email,
       facebook_name: 'change' + @member.facebook_name,
-      twitter_handle: 'change' + @member.twitter_handle
+      twitter_handle: 'change' + @member.twitter_handle,
+      instagram_handle: 'change' + @member.instagram_handle
     }
     
     patch :update, params: { 

--- a/test/fixtures/members.yml
+++ b/test/fixtures/members.yml
@@ -26,6 +26,7 @@ one:
   relative_email: relative@example.com
   facebook_name: facebookname
   twitter_handle: twitterhandle
+  instagram_handle: instagramhandle
 
 two:
   first_name: MyString
@@ -53,6 +54,7 @@ two:
   relative_email: relative@example.com
   facebook_name: facebookname
   twitter_handle: twitterhandle
+  instagram_handle: instagramhandle
 
 three:
   first_name: MyString
@@ -84,6 +86,7 @@ jane:
   relative_email: relative@example.com
   facebook_name: facebookname
   twitter_handle: twitterhandle
+  instagram_handle: instagramhandle
 
 john:
   first_name: John
@@ -94,6 +97,7 @@ john:
   relative_email: relative@example.com
   facebook_name: facebookname
   twitter_handle: twitterhandle
+  instagram_handle: instagramhandle
 
 martin:
   first_name: Martin
@@ -105,6 +109,7 @@ martin:
   relative_email: relative@example.com
   facebook_name: facebookname
   twitter_handle: twitterhandle
+  instagram_handle: instagramhandle
 
 george:
   first_name: George
@@ -115,6 +120,7 @@ george:
   relative_email: relative@example.com
   facebook_name: facebookname
   twitter_handle: twitterhandle
+  instagram_handle: instagramhandle
 
 rosa:
   first_name: Rosa
@@ -125,6 +131,7 @@ rosa:
   relative_email: relative@example.com
   facebook_name: facebookname
   twitter_handle: twitterhandle
+  instagram_handle: instagramhandle
 
 carrie:
   first_name: Carrie
@@ -135,6 +142,7 @@ carrie:
   relative_email: relative@example.com
   facebook_name: facebookname
   twitter_handle: twitterhandle
+  instagram_handle: instagramhandle
 
 ossie:
   first_name: Ossie
@@ -145,6 +153,7 @@ ossie:
   relative_email: relative@example.com
   facebook_name: facebookname
   twitter_handle: twitterhandle
+  instagram_handle: instagramhandle
 
 malachi:
   first_name: Malachi
@@ -155,3 +164,4 @@ malachi:
   relative_email: relative@example.com
   facebook_name: facebookname
   twitter_handle: twitterhandle
+  instagram_handle: instagramhandle

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -50,5 +50,10 @@ class MemberTest < ActiveSupport::TestCase
     member = Member.new(first_name: 'First', last_name: 'Last', twitter_handle: 'twitterhandle')
     assert member.save 
   end
+  
+  test 'should save member with instagram handle' do
+    member = Member.new(first_name: 'First', last_name: 'Last', instagram_handle: 'instagramhandle')
+    assert member.save 
+  end
     
 end


### PR DESCRIPTION
In order to have better contact information to followup with
student's for longitudinal tracking, a instagram handle field has
been added to the member profile.