### PR TITLE
Add sex to the member model

### DIFF
--- a/app/analytics/etl/dimensions/member.rb
+++ b/app/analytics/etl/dimensions/member.rb
@@ -11,7 +11,8 @@ class Etl::Dimensions::Member
                 state: member.state,
                 zip: member.zip_code,
                 high_school_gpa: member.high_school_gpa,
-                act_score: member.act_score
+                act_score: member.act_score,
+                sex: member.sex
             }
 
             if MemberDimension.where(member_id: attributes[:member_id]).exists?

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -183,6 +183,7 @@ class MembersController < ApplicationController
         :facebook_name,
         :twitter_handle,
         :instagram_handle,
+        :sex,
         :organization_ids => [], 
         :neighborhood_ids => [], 
         :extracurricular_activity_ids => [], 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -39,6 +39,10 @@ class Member < ApplicationRecord
   has_many :communications, dependent: :destroy
   has_many :network_actions, dependent: :destroy, foreign_key: :actor_id
 
+  def self.sexes
+    %w{ Female Male }
+  end
+  
   def self.shirt_sizes
     %w{ S M L XL 2XL 3XL }
   end

--- a/app/views/members/_form.html.erb
+++ b/app/views/members/_form.html.erb
@@ -24,6 +24,15 @@
   </div>
 </div>
 <div class="form-group">
+  <%= f.label :sex, class: "col-sm-2 control-label" %>
+  <div class="col-sm-10">
+    <%= f.select :sex,
+          Member.sexes,
+          {include_blank: true},
+          class: "select2 form-control" %>
+  </div>
+</div>
+<div class="form-group">
   <%= f.label :date_of_birth, class: "col-sm-2 control-label" %>
   <div class="col-sm-10">
     <%= f.date_field :date_of_birth, min: 150.years.ago, max: Date.today, class: "form-control" %>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -17,6 +17,9 @@
   <dt>Last name:</dt>
   <dd><%= @member.last_name %></dd>
 
+  <dt>Sex:</dt>
+  <dd><%= @member.sex %></dd>
+  
   <dt>Date of Birth:</dt>
   <% if @member.date_of_birth.present? %>
     <dd><%= @member.try(:date_of_birth).strftime('%m/%d/%Y') %></dd>

--- a/db/migrate/20180629131250_add_sex_to_members.rb
+++ b/db/migrate/20180629131250_add_sex_to_members.rb
@@ -1,0 +1,5 @@
+class AddSexToMembers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :members, :sex, :string
+  end
+end

--- a/db/migrate/20180629133853_add_sex_to_member_dimension.rb
+++ b/db/migrate/20180629133853_add_sex_to_member_dimension.rb
@@ -1,0 +1,5 @@
+class AddSexToMemberDimension < ActiveRecord::Migration[5.2]
+  def change
+    add_column :member_dimensions, :sex, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_28_142724) do
+ActiveRecord::Schema.define(version: 2018_06_29_133853) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -180,6 +180,7 @@ ActiveRecord::Schema.define(version: 2018_06_28_142724) do
     t.integer "member_id"
     t.float "high_school_gpa"
     t.integer "act_score"
+    t.string "sex"
   end
 
   create_table "members", force: :cascade do |t|
@@ -214,6 +215,7 @@ ActiveRecord::Schema.define(version: 2018_06_28_142724) do
     t.string "facebook_name"
     t.string "twitter_handle"
     t.string "instagram_handle"
+    t.string "sex"
     t.index ["identity_id"], name: "index_members_on_identity_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -88,6 +88,7 @@ victoria = Member.create(
   facebook_name: 'facebookname',
   twitter_handle: 'twitterhandle',
   instagram_handle: 'instagramhandle',
+  sex: 'Female',
   user_id: user.id
 )
 chris = Member.create(
@@ -105,6 +106,7 @@ chris = Member.create(
   facebook_name: 'facebookname',
   twitter_handle: 'twitterhandle',
   instagram_handle: 'instagramhandle',
+  sex: 'Male',
   user_id: user.id
 )
 andrew = Member.create(
@@ -122,6 +124,7 @@ andrew = Member.create(
   facebook_name: 'facebookname',
   twitter_handle: 'twitterhandle',
   instagram_handle: 'instagramhandle',
+  sex: 'Male',
   user_id: user.id
 )
 sean = Member.create(
@@ -139,6 +142,7 @@ sean = Member.create(
   facebook_name: 'facebookname',
   twitter_handle: 'twitterhandle',
   instagram_handle: 'instagramhandle',
+  sex: 'Male',
   user_id: user.id
 )
 
@@ -177,6 +181,7 @@ student_nell = Member.create(
   facebook_name: 'facebookname',
   twitter_handle: 'twitterhandle',
   instagram_handle: 'instagramhandle',
+  sex: 'Female',
   user_id: user.id
 )
 
@@ -286,6 +291,7 @@ identity_enumerator = Identity.all.cycle
     facebook_name: 'facebookname',
     twitter_handle: 'twitterhandle',
     instagram_handle: 'instagramhandle',
+    sex: 'Female',
     user_id: user.id,
     identity: identity_enumerator.next
   )

--- a/test/controllers/members_controller_test.rb
+++ b/test/controllers/members_controller_test.rb
@@ -24,6 +24,7 @@ class MembersControllerTest < ActionController::TestCase
     assert_select "input[name='member[facebook_name]']"
     assert_select "input[name='member[twitter_handle]']"
     assert_select "input[name='member[instagram_handle]']"
+    assert_select "select[name='member[sex]']"
   end
 
   test "should create member" do
@@ -51,7 +52,8 @@ class MembersControllerTest < ActionController::TestCase
       relative_email: @member.relative_email,
       facebook_name: @member.facebook_name,
       twitter_handle: @member.twitter_handle,
-      instagram_handle: @member.instagram_handle
+      instagram_handle: @member.instagram_handle,
+      sex: @member.sex
     }
     
     assert_difference('Member.count') do
@@ -85,6 +87,8 @@ class MembersControllerTest < ActionController::TestCase
     assert_select 'dd', @member.twitter_handle
     assert_select 'dt', 'Instagram Handle:'
     assert_select 'dd', @member.instagram_handle
+    assert_select 'dt', 'Sex:'
+    assert_select 'dd', @member.sex
   end
 
   test "should get edit" do
@@ -97,6 +101,7 @@ class MembersControllerTest < ActionController::TestCase
     assert_select "input[name='member[facebook_name]']"
     assert_select "input[name='member[twitter_handle]']"
     assert_select "input[name='member[instagram_handle]']"
+    assert_select "select[name='member[sex]']"
   end
 
   test "should update member" do
@@ -124,7 +129,8 @@ class MembersControllerTest < ActionController::TestCase
       relative_email: 'change.' + @member.relative_email,
       facebook_name: 'change' + @member.facebook_name,
       twitter_handle: 'change' + @member.twitter_handle,
-      instagram_handle: 'change' + @member.instagram_handle
+      instagram_handle: 'change' + @member.instagram_handle,
+      sex: 'change' + @member.sex
     }
     
     patch :update, params: { 

--- a/test/etl/dimensions/member_test.rb
+++ b/test/etl/dimensions/member_test.rb
@@ -12,7 +12,8 @@ class ETLDimensionsMemberTest < ActiveSupport::TestCase
           state: 'AL',
           zip_code: '35205',
           high_school_gpa: 4.0,
-          act_score: 24
+          act_score: 24,
+          sex: 'Female'
       )
       @member.save
 
@@ -68,5 +69,9 @@ class ETLDimensionsMemberTest < ActiveSupport::TestCase
   
   test 'ACT Score is extracted' do
     assert_equal @member.act_score, @member_dimension.act_score
+  end
+  
+  test 'Sex is extracted' do
+    assert_equal @member.sex, @member_dimension.sex
   end
 end

--- a/test/fixtures/members.yml
+++ b/test/fixtures/members.yml
@@ -27,6 +27,7 @@ one:
   facebook_name: facebookname
   twitter_handle: twitterhandle
   instagram_handle: instagramhandle
+  sex: Female
 
 two:
   first_name: MyString
@@ -55,6 +56,7 @@ two:
   facebook_name: facebookname
   twitter_handle: twitterhandle
   instagram_handle: instagramhandle
+  sex: Female
 
 three:
   first_name: MyString
@@ -76,6 +78,13 @@ three:
   school: tuggle
   graduating_class: class_of_2017
   high_school_gpa: 4.0
+  act_score: 25
+  relative_phone: 2056687777
+  relative_email: relative@example.com
+  facebook_name: facebookname
+  twitter_handle: twitterhandle
+  instagram_handle: instagramhandle
+  sex: Female
 
 jane:
   first_name: Jane
@@ -87,6 +96,7 @@ jane:
   facebook_name: facebookname
   twitter_handle: twitterhandle
   instagram_handle: instagramhandle
+  sex: Female
 
 john:
   first_name: John
@@ -98,6 +108,7 @@ john:
   facebook_name: facebookname
   twitter_handle: twitterhandle
   instagram_handle: instagramhandle
+  sex: Male
 
 martin:
   first_name: Martin
@@ -110,6 +121,7 @@ martin:
   facebook_name: facebookname
   twitter_handle: twitterhandle
   instagram_handle: instagramhandle
+  sex: Male
 
 george:
   first_name: George
@@ -121,6 +133,7 @@ george:
   facebook_name: facebookname
   twitter_handle: twitterhandle
   instagram_handle: instagramhandle
+  sex: Male
 
 rosa:
   first_name: Rosa
@@ -132,6 +145,7 @@ rosa:
   facebook_name: facebookname
   twitter_handle: twitterhandle
   instagram_handle: instagramhandle
+  sex: Female
 
 carrie:
   first_name: Carrie
@@ -143,6 +157,7 @@ carrie:
   facebook_name: facebookname
   twitter_handle: twitterhandle
   instagram_handle: instagramhandle
+  sex: Female
 
 ossie:
   first_name: Ossie
@@ -154,6 +169,7 @@ ossie:
   facebook_name: facebookname
   twitter_handle: twitterhandle
   instagram_handle: instagramhandle
+  sex: Female
 
 malachi:
   first_name: Malachi
@@ -165,3 +181,4 @@ malachi:
   facebook_name: facebookname
   twitter_handle: twitterhandle
   instagram_handle: instagramhandle
+  sex: Male

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -55,5 +55,10 @@ class MemberTest < ActiveSupport::TestCase
     member = Member.new(first_name: 'First', last_name: 'Last', instagram_handle: 'instagramhandle')
     assert member.save 
   end
+  
+  test 'should save member with sex' do
+    member = Member.new(first_name: 'First', last_name: 'Last', sex: 'Female')
+    assert member.save 
+  end
     
 end


### PR DESCRIPTION
In order to have better demographic information to followup with
student's for longitudinal tracking, a sex field has
been added to the member profile to be able to report on outcomes
by the sex of the student.