### PR TITLE
Add race to the member model

### DIFF
--- a/app/analytics/etl/dimensions/member.rb
+++ b/app/analytics/etl/dimensions/member.rb
@@ -12,7 +12,8 @@ class Etl::Dimensions::Member
                 zip: member.zip_code,
                 high_school_gpa: member.high_school_gpa,
                 act_score: member.act_score,
-                sex: member.sex
+                sex: member.sex,
+                race: member.race
             }
 
             if MemberDimension.where(member_id: attributes[:member_id]).exists?

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -184,6 +184,7 @@ class MembersController < ApplicationController
         :twitter_handle,
         :instagram_handle,
         :sex,
+        :race,
         :organization_ids => [], 
         :neighborhood_ids => [], 
         :extracurricular_activity_ids => [], 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -39,6 +39,16 @@ class Member < ApplicationRecord
   has_many :communications, dependent: :destroy
   has_many :network_actions, dependent: :destroy, foreign_key: :actor_id
 
+  def self.races
+    %w{
+      American\ Indian\ or\ Alaska\ Native
+      Asian
+      Black\ or\ African\ American
+      Native\ Hawaiian\ or\ Other\ Pacific\ Islander
+      White
+    }
+  end
+  
   def self.sexes
     %w{ Female Male }
   end

--- a/app/views/members/_form.html.erb
+++ b/app/views/members/_form.html.erb
@@ -33,6 +33,15 @@
   </div>
 </div>
 <div class="form-group">
+  <%= f.label :race, class: "col-sm-2 control-label" %>
+  <div class="col-sm-10">
+    <%= f.select :race,
+          Member.races,
+          {include_blank: true},
+          class: "select2 form-control" %>
+  </div>
+</div>
+<div class="form-group">
   <%= f.label :date_of_birth, class: "col-sm-2 control-label" %>
   <div class="col-sm-10">
     <%= f.date_field :date_of_birth, min: 150.years.ago, max: Date.today, class: "form-control" %>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -20,6 +20,9 @@
   <dt>Sex:</dt>
   <dd><%= @member.sex %></dd>
   
+  <dt>Race:</dt>
+  <dd><%= @member.race %></dd>
+  
   <dt>Date of Birth:</dt>
   <% if @member.date_of_birth.present? %>
     <dd><%= @member.try(:date_of_birth).strftime('%m/%d/%Y') %></dd>

--- a/db/migrate/20180629143405_add_race_to_members.rb
+++ b/db/migrate/20180629143405_add_race_to_members.rb
@@ -1,0 +1,5 @@
+class AddRaceToMembers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :members, :race, :string
+  end
+end

--- a/db/migrate/20180629145041_add_race_to_member_dimension.rb
+++ b/db/migrate/20180629145041_add_race_to_member_dimension.rb
@@ -1,0 +1,5 @@
+class AddRaceToMemberDimension < ActiveRecord::Migration[5.2]
+  def change
+    add_column :member_dimensions, :race, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_29_133853) do
+ActiveRecord::Schema.define(version: 2018_06_29_145041) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -181,6 +181,7 @@ ActiveRecord::Schema.define(version: 2018_06_29_133853) do
     t.float "high_school_gpa"
     t.integer "act_score"
     t.string "sex"
+    t.string "race"
   end
 
   create_table "members", force: :cascade do |t|
@@ -216,6 +217,7 @@ ActiveRecord::Schema.define(version: 2018_06_29_133853) do
     t.string "twitter_handle"
     t.string "instagram_handle"
     t.string "sex"
+    t.string "race"
     t.index ["identity_id"], name: "index_members_on_identity_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -89,6 +89,7 @@ victoria = Member.create(
   twitter_handle: 'twitterhandle',
   instagram_handle: 'instagramhandle',
   sex: 'Female',
+  race: 'Black or African American',
   user_id: user.id
 )
 chris = Member.create(
@@ -107,6 +108,7 @@ chris = Member.create(
   twitter_handle: 'twitterhandle',
   instagram_handle: 'instagramhandle',
   sex: 'Male',
+  race: 'Black or African American',
   user_id: user.id
 )
 andrew = Member.create(
@@ -125,6 +127,7 @@ andrew = Member.create(
   twitter_handle: 'twitterhandle',
   instagram_handle: 'instagramhandle',
   sex: 'Male',
+  race: 'Black or African American',
   user_id: user.id
 )
 sean = Member.create(
@@ -143,6 +146,7 @@ sean = Member.create(
   twitter_handle: 'twitterhandle',
   instagram_handle: 'instagramhandle',
   sex: 'Male',
+  race: 'Black or African American',
   user_id: user.id
 )
 
@@ -182,6 +186,7 @@ student_nell = Member.create(
   twitter_handle: 'twitterhandle',
   instagram_handle: 'instagramhandle',
   sex: 'Female',
+  race: 'Black or African American',
   user_id: user.id
 )
 
@@ -292,6 +297,7 @@ identity_enumerator = Identity.all.cycle
     twitter_handle: 'twitterhandle',
     instagram_handle: 'instagramhandle',
     sex: 'Female',
+    race: 'Black or African American',
     user_id: user.id,
     identity: identity_enumerator.next
   )

--- a/test/controllers/members_controller_test.rb
+++ b/test/controllers/members_controller_test.rb
@@ -25,6 +25,7 @@ class MembersControllerTest < ActionController::TestCase
     assert_select "input[name='member[twitter_handle]']"
     assert_select "input[name='member[instagram_handle]']"
     assert_select "select[name='member[sex]']"
+    assert_select "select[name='member[race]']"
   end
 
   test "should create member" do
@@ -53,7 +54,8 @@ class MembersControllerTest < ActionController::TestCase
       facebook_name: @member.facebook_name,
       twitter_handle: @member.twitter_handle,
       instagram_handle: @member.instagram_handle,
-      sex: @member.sex
+      sex: @member.sex,
+      race: @member.race
     }
     
     assert_difference('Member.count') do
@@ -89,6 +91,8 @@ class MembersControllerTest < ActionController::TestCase
     assert_select 'dd', @member.instagram_handle
     assert_select 'dt', 'Sex:'
     assert_select 'dd', @member.sex
+    assert_select 'dt', 'Race:'
+    assert_select 'dd', @member.race
   end
 
   test "should get edit" do
@@ -102,6 +106,7 @@ class MembersControllerTest < ActionController::TestCase
     assert_select "input[name='member[twitter_handle]']"
     assert_select "input[name='member[instagram_handle]']"
     assert_select "select[name='member[sex]']"
+    assert_select "select[name='member[race]']"
   end
 
   test "should update member" do
@@ -130,7 +135,8 @@ class MembersControllerTest < ActionController::TestCase
       facebook_name: 'change' + @member.facebook_name,
       twitter_handle: 'change' + @member.twitter_handle,
       instagram_handle: 'change' + @member.instagram_handle,
-      sex: 'change' + @member.sex
+      sex: 'change' + @member.sex,
+      race: 'change' + @member.race
     }
     
     patch :update, params: { 

--- a/test/etl/dimensions/member_test.rb
+++ b/test/etl/dimensions/member_test.rb
@@ -13,7 +13,8 @@ class ETLDimensionsMemberTest < ActiveSupport::TestCase
           zip_code: '35205',
           high_school_gpa: 4.0,
           act_score: 24,
-          sex: 'Female'
+          sex: 'Female',
+          race: 'Black or African American'
       )
       @member.save
 
@@ -73,5 +74,9 @@ class ETLDimensionsMemberTest < ActiveSupport::TestCase
   
   test 'Sex is extracted' do
     assert_equal @member.sex, @member_dimension.sex
+  end
+  
+  test 'Race is extracted' do
+    assert_equal @member.race, @member_dimension.race
   end
 end

--- a/test/fixtures/members.yml
+++ b/test/fixtures/members.yml
@@ -28,6 +28,7 @@ one:
   twitter_handle: twitterhandle
   instagram_handle: instagramhandle
   sex: Female
+  race: Black or African American
 
 two:
   first_name: MyString
@@ -57,6 +58,7 @@ two:
   twitter_handle: twitterhandle
   instagram_handle: instagramhandle
   sex: Female
+  race: Black or African American
 
 three:
   first_name: MyString
@@ -85,6 +87,7 @@ three:
   twitter_handle: twitterhandle
   instagram_handle: instagramhandle
   sex: Female
+  race: Black or African American
 
 jane:
   first_name: Jane
@@ -97,6 +100,7 @@ jane:
   twitter_handle: twitterhandle
   instagram_handle: instagramhandle
   sex: Female
+  race: Black or African American
 
 john:
   first_name: John
@@ -109,6 +113,7 @@ john:
   twitter_handle: twitterhandle
   instagram_handle: instagramhandle
   sex: Male
+  race: Black or African American
 
 martin:
   first_name: Martin
@@ -122,6 +127,7 @@ martin:
   twitter_handle: twitterhandle
   instagram_handle: instagramhandle
   sex: Male
+  race: Black or African American
 
 george:
   first_name: George
@@ -134,6 +140,7 @@ george:
   twitter_handle: twitterhandle
   instagram_handle: instagramhandle
   sex: Male
+  race: Black or African American
 
 rosa:
   first_name: Rosa
@@ -146,6 +153,7 @@ rosa:
   twitter_handle: twitterhandle
   instagram_handle: instagramhandle
   sex: Female
+  race: Black or African American
 
 carrie:
   first_name: Carrie
@@ -158,6 +166,7 @@ carrie:
   twitter_handle: twitterhandle
   instagram_handle: instagramhandle
   sex: Female
+  race: Black or African American
 
 ossie:
   first_name: Ossie
@@ -170,6 +179,7 @@ ossie:
   twitter_handle: twitterhandle
   instagram_handle: instagramhandle
   sex: Female
+  race: Black or African American
 
 malachi:
   first_name: Malachi
@@ -182,3 +192,4 @@ malachi:
   twitter_handle: twitterhandle
   instagram_handle: instagramhandle
   sex: Male
+  race: Black or African American

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -60,5 +60,10 @@ class MemberTest < ActiveSupport::TestCase
     member = Member.new(first_name: 'First', last_name: 'Last', sex: 'Female')
     assert member.save 
   end
+  
+  test 'should save member with race' do
+    member = Member.new(first_name: 'First', last_name: 'Last', race: 'Black or African American')
+    assert member.save 
+  end
     
 end


### PR DESCRIPTION
In order to have better demographic information to followup with
student's for longitudinal tracking, a race field has
been added to the member profile to be able to report on outcomes
by the race of the student.