### PR TITLE
Add ethnicity to the member model

### DIFF
--- a/app/analytics/etl/dimensions/member.rb
+++ b/app/analytics/etl/dimensions/member.rb
@@ -13,7 +13,8 @@ class Etl::Dimensions::Member
                 high_school_gpa: member.high_school_gpa,
                 act_score: member.act_score,
                 sex: member.sex,
-                race: member.race
+                race: member.race,
+                ethnicity: member.ethnicity
             }
 
             if MemberDimension.where(member_id: attributes[:member_id]).exists?

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -185,6 +185,7 @@ class MembersController < ApplicationController
         :instagram_handle,
         :sex,
         :race,
+        :ethnicity,
         :organization_ids => [], 
         :neighborhood_ids => [], 
         :extracurricular_activity_ids => [], 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -39,6 +39,13 @@ class Member < ApplicationRecord
   has_many :communications, dependent: :destroy
   has_many :network_actions, dependent: :destroy, foreign_key: :actor_id
 
+  def self.ethnicities
+    %w{
+      Hispanic\ or\ Latino\ or\ Spanish\ Origin
+      Not\ Hispanic\ or\ Latino\ or\ Spanish\ Origin
+    }
+  end
+  
   def self.races
     %w{
       American\ Indian\ or\ Alaska\ Native

--- a/app/views/members/_form.html.erb
+++ b/app/views/members/_form.html.erb
@@ -42,6 +42,15 @@
   </div>
 </div>
 <div class="form-group">
+  <%= f.label :ethnicity, class: "col-sm-2 control-label" %>
+  <div class="col-sm-10">
+    <%= f.select :ethnicity,
+          Member.ethnicities,
+          {include_blank: true},
+          class: "select2 form-control" %>
+  </div>
+</div>
+<div class="form-group">
   <%= f.label :date_of_birth, class: "col-sm-2 control-label" %>
   <div class="col-sm-10">
     <%= f.date_field :date_of_birth, min: 150.years.ago, max: Date.today, class: "form-control" %>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -23,6 +23,9 @@
   <dt>Race:</dt>
   <dd><%= @member.race %></dd>
   
+  <dt>Ethnicity:</dt>
+  <dd><%= @member.ethnicity %></dd>
+  
   <dt>Date of Birth:</dt>
   <% if @member.date_of_birth.present? %>
     <dd><%= @member.try(:date_of_birth).strftime('%m/%d/%Y') %></dd>

--- a/db/migrate/20180630130559_add_ethnicity_to_members.rb
+++ b/db/migrate/20180630130559_add_ethnicity_to_members.rb
@@ -1,0 +1,5 @@
+class AddEthnicityToMembers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :members, :ethnicity, :string
+  end
+end

--- a/db/migrate/20180630132425_add_ethnicity_to_member_dimensions.rb
+++ b/db/migrate/20180630132425_add_ethnicity_to_member_dimensions.rb
@@ -1,0 +1,5 @@
+class AddEthnicityToMemberDimensions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :member_dimensions, :ethnicity, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_29_145041) do
+ActiveRecord::Schema.define(version: 2018_06_30_132425) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -182,6 +182,7 @@ ActiveRecord::Schema.define(version: 2018_06_29_145041) do
     t.integer "act_score"
     t.string "sex"
     t.string "race"
+    t.string "ethnicity"
   end
 
   create_table "members", force: :cascade do |t|
@@ -218,6 +219,7 @@ ActiveRecord::Schema.define(version: 2018_06_29_145041) do
     t.string "instagram_handle"
     t.string "sex"
     t.string "race"
+    t.string "ethnicity"
     t.index ["identity_id"], name: "index_members_on_identity_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -90,6 +90,7 @@ victoria = Member.create(
   instagram_handle: 'instagramhandle',
   sex: 'Female',
   race: 'Black or African American',
+  ethnicity: 'Not Hispanic or Latino or Spanish Origin',
   user_id: user.id
 )
 chris = Member.create(
@@ -109,6 +110,7 @@ chris = Member.create(
   instagram_handle: 'instagramhandle',
   sex: 'Male',
   race: 'Black or African American',
+  ethnicity: 'Not Hispanic or Latino or Spanish Origin',
   user_id: user.id
 )
 andrew = Member.create(
@@ -128,6 +130,7 @@ andrew = Member.create(
   instagram_handle: 'instagramhandle',
   sex: 'Male',
   race: 'Black or African American',
+  ethnicity: 'Not Hispanic or Latino or Spanish Origin',
   user_id: user.id
 )
 sean = Member.create(
@@ -147,6 +150,7 @@ sean = Member.create(
   instagram_handle: 'instagramhandle',
   sex: 'Male',
   race: 'Black or African American',
+  ethnicity: 'Not Hispanic or Latino or Spanish Origin',
   user_id: user.id
 )
 
@@ -187,6 +191,7 @@ student_nell = Member.create(
   instagram_handle: 'instagramhandle',
   sex: 'Female',
   race: 'Black or African American',
+  ethnicity: 'Not Hispanic or Latino or Spanish Origin',
   user_id: user.id
 )
 
@@ -298,6 +303,7 @@ identity_enumerator = Identity.all.cycle
     instagram_handle: 'instagramhandle',
     sex: 'Female',
     race: 'Black or African American',
+    ethnicity: 'Not Hispanic or Latino or Spanish Origin',
     user_id: user.id,
     identity: identity_enumerator.next
   )

--- a/test/controllers/members_controller_test.rb
+++ b/test/controllers/members_controller_test.rb
@@ -26,6 +26,7 @@ class MembersControllerTest < ActionController::TestCase
     assert_select "input[name='member[instagram_handle]']"
     assert_select "select[name='member[sex]']"
     assert_select "select[name='member[race]']"
+    assert_select "select[name='member[ethnicity]']"
   end
 
   test "should create member" do
@@ -55,7 +56,8 @@ class MembersControllerTest < ActionController::TestCase
       twitter_handle: @member.twitter_handle,
       instagram_handle: @member.instagram_handle,
       sex: @member.sex,
-      race: @member.race
+      race: @member.race,
+      ethnicity: @member.ethnicity
     }
     
     assert_difference('Member.count') do
@@ -93,6 +95,8 @@ class MembersControllerTest < ActionController::TestCase
     assert_select 'dd', @member.sex
     assert_select 'dt', 'Race:'
     assert_select 'dd', @member.race
+    assert_select 'dt', 'Ethnicity:'
+    assert_select 'dd', @member.ethnicity
   end
 
   test "should get edit" do
@@ -107,6 +111,7 @@ class MembersControllerTest < ActionController::TestCase
     assert_select "input[name='member[instagram_handle]']"
     assert_select "select[name='member[sex]']"
     assert_select "select[name='member[race]']"
+    assert_select "select[name='member[ethnicity]']"
   end
 
   test "should update member" do
@@ -136,7 +141,8 @@ class MembersControllerTest < ActionController::TestCase
       twitter_handle: 'change' + @member.twitter_handle,
       instagram_handle: 'change' + @member.instagram_handle,
       sex: 'change' + @member.sex,
-      race: 'change' + @member.race
+      race: 'change' + @member.race,
+      ethnicity: 'change' + @member.ethnicity
     }
     
     patch :update, params: { 

--- a/test/etl/dimensions/member_test.rb
+++ b/test/etl/dimensions/member_test.rb
@@ -14,7 +14,8 @@ class ETLDimensionsMemberTest < ActiveSupport::TestCase
           high_school_gpa: 4.0,
           act_score: 24,
           sex: 'Female',
-          race: 'Black or African American'
+          race: 'Black or African American',
+          ethnicity: 'Not Hispanic or Latino or Spanish Origin'
       )
       @member.save
 
@@ -78,5 +79,9 @@ class ETLDimensionsMemberTest < ActiveSupport::TestCase
   
   test 'Race is extracted' do
     assert_equal @member.race, @member_dimension.race
+  end
+  
+  test 'Ethnicity is extracted' do
+    assert_equal @member.ethnicity, @member_dimension.ethnicity
   end
 end

--- a/test/fixtures/members.yml
+++ b/test/fixtures/members.yml
@@ -29,6 +29,7 @@ one:
   instagram_handle: instagramhandle
   sex: Female
   race: Black or African American
+  ethnicity: Hispanic or Latino or Spanish Origin
 
 two:
   first_name: MyString
@@ -59,6 +60,7 @@ two:
   instagram_handle: instagramhandle
   sex: Female
   race: Black or African American
+  ethnicity: Hispanic or Latino or Spanish Origin
 
 three:
   first_name: MyString
@@ -88,6 +90,7 @@ three:
   instagram_handle: instagramhandle
   sex: Female
   race: Black or African American
+  ethnicity: Hispanic or Latino or Spanish Origin
 
 jane:
   first_name: Jane
@@ -101,6 +104,7 @@ jane:
   instagram_handle: instagramhandle
   sex: Female
   race: Black or African American
+  ethnicity: Hispanic or Latino or Spanish Origin
 
 john:
   first_name: John
@@ -114,6 +118,7 @@ john:
   instagram_handle: instagramhandle
   sex: Male
   race: Black or African American
+  ethnicity: Hispanic or Latino or Spanish Origin
 
 martin:
   first_name: Martin
@@ -128,6 +133,7 @@ martin:
   instagram_handle: instagramhandle
   sex: Male
   race: Black or African American
+  ethnicity: Hispanic or Latino or Spanish Origin
 
 george:
   first_name: George
@@ -141,6 +147,7 @@ george:
   instagram_handle: instagramhandle
   sex: Male
   race: Black or African American
+  ethnicity: Hispanic or Latino or Spanish Origin
 
 rosa:
   first_name: Rosa
@@ -154,6 +161,7 @@ rosa:
   instagram_handle: instagramhandle
   sex: Female
   race: Black or African American
+  ethnicity: Hispanic or Latino or Spanish Origin
 
 carrie:
   first_name: Carrie
@@ -167,6 +175,7 @@ carrie:
   instagram_handle: instagramhandle
   sex: Female
   race: Black or African American
+  ethnicity: Hispanic or Latino or Spanish Origin
 
 ossie:
   first_name: Ossie
@@ -180,6 +189,7 @@ ossie:
   instagram_handle: instagramhandle
   sex: Female
   race: Black or African American
+  ethnicity: Hispanic or Latino or Spanish Origin
 
 malachi:
   first_name: Malachi
@@ -193,3 +203,4 @@ malachi:
   instagram_handle: instagramhandle
   sex: Male
   race: Black or African American
+  ethnicity: Hispanic or Latino or Spanish Origin

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -65,5 +65,10 @@ class MemberTest < ActiveSupport::TestCase
     member = Member.new(first_name: 'First', last_name: 'Last', race: 'Black or African American')
     assert member.save 
   end
+  
+  test 'should save member with ethnicity' do
+    member = Member.new(first_name: 'First', last_name: 'Last', ethnicity: 'Hispanic or Latino or Spanish Origin')
+    assert member.save 
+  end
     
 end


### PR DESCRIPTION
In order to have better demographic information to followup with
student's for longitudinal tracking, an ethnicity field has
been added to the member profile to be able to report on outcomes
by the ethnicity of the student.