### PR TITLE
Changed event emails sender to current user

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -12,7 +12,13 @@ class MessagesController < ApplicationController
     @message.sender = current_user
 
     if @message.valid? && @message.save
-      MessageMailer.message_email(network_event.name, @message.subject, @message.body, mailer_recipients).deliver
+      MessageMailer.message_email(
+        network_event.name, 
+        @message.subject, 
+        @message.body, 
+        current_user.email,
+        mailer_recipients
+      ).deliver
 
       redirect_to network_event_message_path(network_event, @message)
     else
@@ -28,7 +34,7 @@ class MessagesController < ApplicationController
   private
 
   def mailer_recipients
-    @message.model.member_recipients.pluck(:email) << @message.model.adhoc_recipients.pluck(:email)
+    @message.model.member_recipients.pluck(:email) + @message.model.adhoc_recipients.pluck(:email)
   end
 
   def message_params

--- a/app/mailers/message_mailer.rb
+++ b/app/mailers/message_mailer.rb
@@ -1,11 +1,10 @@
 class MessageMailer < ActionMailer::Base
-  default from: 'no-reply@edbirmingham.com'
- 
-  def message_email(network_event_name, subject, body, recipients)
+  def message_email(network_event_name, subject, body, sender, recipients)
     @network_event_name = network_event_name
     @subject = subject
     @body = body
     mail(
+      from: sender.presence || 'no-reply@edbirmingham.org',
       bcc: Array.wrap(recipients),
       cc: "",
       subject: subject

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -15,12 +15,23 @@ class MessagesControllerTest < ActionController::TestCase
   end
 
   test "'create' action creates a message" do
-    member_id = members(:one).id
+    member_id = members(:malachi).id
     tuggle = network_events(:tuggle_network)
+    
     post :create, params:{ network_event_id: tuggle.id, message: {subject: "hello!", body: "hello everyone", recipient_ids: [member_id]}}
 
     assert_redirected_to network_event_message_path(tuggle, tuggle.messages.last)
 
     assert_equal 1, tuggle.messages.count
+  end
+  
+  test "'create' action sends an email from current user" do
+    member_id = members(:malachi).id
+    tuggle = network_events(:tuggle_network)
+    
+    post :create, params:{ network_event_id: tuggle.id, message: {subject: "hello!", body: "hello everyone", recipient_ids: [member_id]}}
+
+    event_email = ActionMailer::Base.deliveries.last
+    assert_equal [users(:one).email], event_email.from
   end
 end

--- a/test/mailers/message_mailer_test.rb
+++ b/test/mailers/message_mailer_test.rb
@@ -2,16 +2,38 @@ require 'test_helper'
  
 class MessageMailerTest < ActionMailer::TestCase
   test "message_email sends the email" do
-    email = MessageMailer.message_email("The Main Event", "subject", "the <b>body</b> <script> evil javascript </script>", ["x@x.com", "y@y.com"])
+    email = MessageMailer.message_email(
+      "The Main Event", 
+      "subject", 
+      "the <b>body</b> <script> evil javascript </script>", 
+      "a@a.com",
+      ["x@x.com", "y@y.com"]
+    )
  
     assert_emails 1 do
       email.deliver_now
     end
  
-    assert_equal ["no-reply@edbirmingham.com"], email.from
+    assert_equal ["a@a.com"], email.from
     assert_nil email.to
     assert_equal ["x@x.com", "y@y.com"], email.bcc
     assert_equal "subject", email.subject
     assert_equal "<p>\n  Network Event: \n</p>\n<p>\n  Subject: subject\n</p>\n<p>\n  Body: the <b>body</b>  evil javascript \n</p>\n", email.body.to_s
+  end
+  
+  test "message_email uses default email if sender does not have an email" do
+    email = MessageMailer.message_email(
+      "The Main Event", 
+      "subject", 
+      "the <b>body</b> <script> evil javascript </script>", 
+      "",
+      ["x@x.com", "y@y.com"]
+    )
+ 
+    assert_emails 1 do
+      email.deliver_now
+    end
+ 
+    assert_equal ["no-reply@edbirmingham.org"], email.from
   end
 end


### PR DESCRIPTION
Event emails were sent from no-repy email address.  This prevented
recipients from being able to communicate with Ed about the event.
Therefore, the sender is now the currently logged in user so recipients
will be able to reply to the email.