### PR TITLE
Added event details to event messages

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -13,7 +13,7 @@ class MessagesController < ApplicationController
 
     if @message.valid? && @message.save
       MessageMailer.message_email(
-        network_event.name, 
+        network_event, 
         @message.subject, 
         @message.body, 
         current_user.email,

--- a/app/mailers/message_mailer.rb
+++ b/app/mailers/message_mailer.rb
@@ -1,6 +1,6 @@
 class MessageMailer < ActionMailer::Base
-  def message_email(network_event_name, subject, body, sender, recipients)
-    @network_event_name = network_event_name
+  def message_email(network_event, subject, body, sender, recipients)
+    @network_event = network_event
     @subject = subject
     @body = body
     mail(

--- a/app/views/message_mailer/message_email.html.erb
+++ b/app/views/message_mailer/message_email.html.erb
@@ -1,12 +1,21 @@
 <p>
-  Network Event: <%= @network_event %>
-</p>
-<p>
-  Subject: <%= @subject %>
-</p>
-<p>
-  Body: <%= sanitize(@body.html_safe,
+  <%= sanitize(@body.html_safe,
    tags: Rails.application.config.x.allowed_html_tags_in_email,
    attributes: Rails.application.config.x.allowed_html_attributes_in_email) 
   %>
+</p>
+<p>
+  Event Details:
+</p>
+<p>
+  <%= @network_event.name %>
+</p>
+<p>
+  <%= @network_event.program.try(:name) %>
+</p>
+<p>
+  <%= @network_event.location.try(:name) %>
+</p>
+<p>
+  <%= @network_event.scheduled_at.try(:strftime, '%B %-d, %Y at%l:%M%P') %>
 </p>

--- a/test/fixtures/message_mailer/event
+++ b/test/fixtures/message_mailer/event
@@ -1,0 +1,18 @@
+<p>
+  the <b>body</b>  evil javascript 
+</p>
+<p>
+  Event Details:
+</p>
+<p>
+  The Main Event
+</p>
+<p>
+  Network Night
+</p>
+<p>
+  Tuggle Elementary School
+</p>
+<p>
+  January 20, 2018 at 6:00pm
+</p>

--- a/test/mailers/message_mailer_test.rb
+++ b/test/mailers/message_mailer_test.rb
@@ -1,9 +1,18 @@
 require 'test_helper'
  
 class MessageMailerTest < ActionMailer::TestCase
+  setup do
+    @event = NetworkEvent.new(
+      name: "The Main Event",
+      program: programs(:network_night),
+      location: locations(:tuggle),
+      scheduled_at: DateTime.new(2018, 1, 20, 18)
+    )
+  end
+  
   test "message_email sends the email" do
     email = MessageMailer.message_email(
-      "The Main Event", 
+      @event, 
       "subject", 
       "the <b>body</b> <script> evil javascript </script>", 
       "a@a.com",
@@ -18,12 +27,12 @@ class MessageMailerTest < ActionMailer::TestCase
     assert_nil email.to
     assert_equal ["x@x.com", "y@y.com"], email.bcc
     assert_equal "subject", email.subject
-    assert_equal "<p>\n  Network Event: \n</p>\n<p>\n  Subject: subject\n</p>\n<p>\n  Body: the <b>body</b>  evil javascript \n</p>\n", email.body.to_s
+    assert_equal read_fixture('event').join, email.body.to_s
   end
   
   test "message_email uses default email if sender does not have an email" do
     email = MessageMailer.message_email(
-      "The Main Event", 
+      @event, 
       "subject", 
       "the <b>body</b> <script> evil javascript </script>", 
       "",


### PR DESCRIPTION
RE #645: In order to keep the user from having to enter information about the
event to related emails, the event name, program, location and date/time
will be automatically added to the emails.