### PR TITLE
Fixed JS problems related to messages

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,7 @@
 //= require jquery_ujs
 //= require bootstrap-sprockets
 //= require turbolinks
+//= require_tree .
 //= require moment
 //= require select2
 //= require bootstrap-datetimepicker

--- a/app/assets/javascripts/messages.coffee
+++ b/app/assets/javascripts/messages.coffee
@@ -1,2 +1,3 @@
-$(document).on 'ready page:load', ->
-  $('#message_body').summernote()
+$(document).on 'ready page:load turbolinks:load', ->
+  if $('#message_body').summernote
+    $('#message_body').summernote()

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -9,7 +9,6 @@
 
 <link href="//cdnjs.cloudflare.com/ajax/libs/summernote/0.8.6/summernote.css" rel="stylesheet">
 <script src="//cdnjs.cloudflare.com/ajax/libs/summernote/0.8.6/summernote.min.js"></script>
-<%= javascript_include_tag "messages" %>
 
 <%= form_for([network_event, @message], html: { class: "form-horizontal", role: "form" }) do |f| %>
   <% if @message.errors.any? %>


### PR DESCRIPTION
A message page load function call require a javascript library that was
only loaded on the messages new page.  As a result the standard rails
behavior of loading all coffee script files on every page caused a
javascript error.  In order to result this error the default behavior of
loading all files was disabled.  This caused other parts of the site to
quit working since the required coffee script was not being loaded.

To fix the problem, a condition was added to make sure the function was
defined before calling it.

Another option would be to move the required javascript library to the
application layout and load it everywhere.  This was not chosen to keep
from loading the library everywhere.