### PR TITLE
Moved summernote js and css to application layout

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,9 @@
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+    <link href="//cdnjs.cloudflare.com/ajax/libs/summernote/0.8.6/summernote.css" rel="stylesheet">
+    <script src="//cdnjs.cloudflare.com/ajax/libs/summernote/0.8.6/summernote.min.js"></script>
+
     <%= csrf_meta_tags %>
   </head>
   <body>

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -7,9 +7,6 @@
 
 <h1> New Message </h1>
 
-<link href="//cdnjs.cloudflare.com/ajax/libs/summernote/0.8.6/summernote.css" rel="stylesheet">
-<script src="//cdnjs.cloudflare.com/ajax/libs/summernote/0.8.6/summernote.min.js"></script>
-
 <%= form_for([network_event, @message], html: { class: "form-horizontal", role: "form" }) do |f| %>
   <% if @message.errors.any? %>
     <div class="alert alert-danger alert-dismissable" role="alert">


### PR DESCRIPTION
In order to get the libraries to load consistently with turbolinks,
the summernote js and css are being loaded in the head portion of the
page.