### PR TITLE
Minor UI improvements for messages

### DIFF
--- a/app/assets/javascripts/messages.coffee
+++ b/app/assets/javascripts/messages.coffee
@@ -1,3 +1,3 @@
 $(document).on 'ready page:load turbolinks:load', ->
   if $('#message_body').summernote
-    $('#message_body').summernote()
+    $('#message_body').summernote('justifyLeft')

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -10,7 +10,12 @@
   <dd><%= @message.subject %></dd>
 
   <dt>Body:</dt>
-  <dd><%= @message.body %></dd>
+  <dd>
+    <%= sanitize(@message.body.html_safe,
+     tags: Rails.application.config.x.allowed_html_tags_in_email,
+     attributes: Rails.application.config.x.allowed_html_attributes_in_email) 
+    %>
+  </dd>
 
   <dt>Status:</dt>
   <dd><%= @message.status.try(:titleize) %></dd>


### PR DESCRIPTION
The message editor defaulted to center justification.  Now it defaults
to left justification.

The message show page was outputting the HTML on the page.  Added
html_safe to the show page so the body of the email would be formatted
like it was sent.  The HTML email body is sanitized before being
displayed so that malicious JS can't be executed by an email.