### PR TITLE
Fixed Rails 6 deprecation warnings

### DIFF
--- a/app/controllers/network_events_controller.rb
+++ b/app/controllers/network_events_controller.rb
@@ -146,7 +146,11 @@ class NetworkEventsController < ApplicationController
       events = NetworkEvent.
         select("DISTINCT network_events.*, " + sort_column + " IS NULL").
         includes(:program, :location, :organizations, :volunteers).
-        order(sort_column + " IS NULL, " + sort_column + " " + sort_direction)
+        order(
+          Arel.sql(
+            sort_column + " IS NULL, " + sort_column + " " + sort_direction
+          )
+        )
 
       # Filter events by scheduled date.
       if params[:unscheduled_events_only].present?

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -59,7 +59,7 @@ class TasksController < ApplicationController
   def filtered_event_tasks
     tasks = Task.
       includes(:owner, :network_event, :common_task).
-      order("due_date IS NULL, due_date ASC")
+      order(Arel.sql("due_date IS NULL, due_date ASC"))
       
     # Filter members by search term
     if params[:q].present?


### PR DESCRIPTION
Some ActiveRecord order values included potentially unsafe strings.  The
strings were verified to be safe and were wrapped by Arel.sql as
suggested by the deprecation warnings.