### PR TITLE
Improved wording on group member add

### DIFF
--- a/app/views/members/new_in_group.html.erb
+++ b/app/views/members/new_in_group.html.erb
@@ -4,8 +4,9 @@
     Back
   <% end %>
   <h1>New member</h1>
-  <small>Note: While adding members in group, it copies Graduating class Cohorts, 
-  School, Identity, Organizations from previous member to the new member in the series.</small>
+  <small>Note: While adding members in group, it copies identity, cohorts, 
+  school, graduating class, and organizations from previous member to the new 
+  member in the series.</small>
 </div>
 
 <%= form_for(@member, html: { class: "form-horizontal", role: "form" }) do |f| %>


### PR DESCRIPTION
When adding members in a group, some fields like cohorts will be the
same for each member.  To make them easier to enter those fields will be
carried over from one member to the next.  Some wording at the top of
the page explained which fields would be copied over.  The grammar of
the sentence was improved as well as the order of the fields was changed
to match their order on the member form.