### PR TITLE
Fixed Travis CI OTP secret

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: ruby
 rvm:
   - 2.2.7
 env:
-  - RAILS_ENV=test
+  global:
+    - RAILS_ENV=test
+    - OTP_SECRET_ENCRYPTION_KEY=3b542e14a65f3e2615df211c377da2ed7b6d27ef7d6acf6d7717ec19fd192debaefde0ba2bf7cee41a3813b3da84268402b5773904c4d8ff5caba15b88bfacc0
 script:
   - bundle install
   - cp config/database.yml.example config/database.yml

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -273,11 +273,7 @@ Devise.setup do |config|
   config.direct_otp_valid_for = 5.minutes  # Time before direct OTP becomes invalid
   config.direct_otp_length = 6  # Direct OTP code length
   config.remember_otp_session_for_seconds = 30.days  # Time before browser has to perform 2fA again. Default is 0.
-  if Rails.env.test?
-    config.otp_secret_encryption_key = SecureRandom.hex
-  else
-    config.otp_secret_encryption_key = ENV['OTP_SECRET_ENCRYPTION_KEY']
-  end
+  config.otp_secret_encryption_key = ENV['OTP_SECRET_ENCRYPTION_KEY']
   config.second_factor_resource_id = 'id' # Field or method name used to set value for 2fA remember cookie
   config.delete_cookie_on_logout = false # Delete cookie when user signs out, to force 2fA again on login
 end


### PR DESCRIPTION
The first time I tried to set the OTP secret in an environment variable
for Tracis CI I typed OPT instead of OTP.  I did not realize the problem
until after I had hacked a solution.  Now I am unhacking it and makint
it right by setting the value in the .travis.yml file.