### PR TITLE
Add SurveyMonkey account registration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem 'ancestry'
 gem 'zeroclipboard-rails'
 
 # Network Gems
+gem 'omniauth-surveymonkey'
 gem 'devise', '~> 4.1'
 
 # Until the new API calls are generally available, we must manually specify a

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,7 @@ GEM
     ffi (1.9.25)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
+    hashie (3.5.7)
     heroics (0.0.24)
       erubis (~> 2.0)
       excon
@@ -162,6 +163,13 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.8.3)
       mini_portile2 (~> 2.3.0)
+    omniauth (1.8.1)
+      hashie (>= 3.4.6, < 3.6.0)
+      rack (>= 1.6.2, < 3)
+    omniauth-surveymonkey (2.0.1)
+      faraday (~> 0.9)
+      multi_json (~> 1.12)
+      omniauth (~> 1.0)
     orm_adapter (0.5.0)
     pg (1.0.0)
     pg_search (2.1.2)
@@ -308,6 +316,7 @@ DEPENDENCIES
   listen
   mocha
   momentjs-rails (>= 2.9.0)
+  omniauth-surveymonkey
   pg
   pg_search
   platform-api

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -8,6 +8,14 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # def twitter
   # end
 
+  def surveymonkey
+    current_user.surveymonkey_token = request.env["omniauth.auth"].credentials.token
+    current_user.surveymonkey_uid =  request.env["omniauth.auth"].uid
+    current_user.save
+    
+    redirect_to edit_user_registration_path
+  end
+
   # More info at:
   # https://github.com/plataformatec/devise#omniauth
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,8 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :two_factor_authenticatable, :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :rememberable, :trackable, :validatable, :omniauthable, 
+         omniauth_providers: %i[surveymonkey]
   has_one_time_password(encrypted: true)
 
   has_many :created_organizations, class_name: "Organization", foreign_key: :created_by_id
@@ -22,6 +23,10 @@ class User < ApplicationRecord
   
   def need_two_factor_authentication?(request)
     two_factor_auth?
+  end
+  
+  def surveymonkey?
+    surveymonkey_token.present? && surveymonkey_uid.present?
   end
   
   private

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -48,6 +48,20 @@
 
   <div class="form-group">
     <div class="col-sm-offset-2 col-sm-10 text-left">
+      <% if current_user.surveymonkey? %>
+        <span class="bg-success">SurveyMonkey account registered.</span>
+      <% else %>
+        <%= link_to('Register SurverMonkey account', user_surveymonkey_omniauth_authorize_path) %>
+        <span id="twoFactorHelpBlock" class="help-block">
+          In order to register your SurveyMonkey account, you will need to have 
+          received an account from your SurveyMonkey organization.
+        </span>
+      <% end %>
+    </div>
+  </div>
+  
+  <div class="form-group">
+    <div class="col-sm-offset-2 col-sm-10 text-left">
       <div class="checkbox">
         <%= f.label :two_factor_auth, capture { %>
           <%= f.check_box :two_factor_auth, "aria-describedby": "twoFactorHelpBlock" %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,3 +1,6 @@
+require 'omniauth'
+require 'omniauth-surveymonkey/omniauth-surveymonkey'
+
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
@@ -242,6 +245,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+  config.omniauth :surveymonkey, ENV['SURVEYMONKEY_CLIENT_ID'], ENV['SURVEYMONKEY_API_KEY'], ENV['SURVEYMONKEY_SECRET']
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,8 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {
     sessions:      'users/sessions',
     passwords:     'users/passwords',
-    registrations: 'users/registrations'
+    registrations: 'users/registrations',
+    omniauth_callbacks: 'users/omniauth_callbacks' 
   }
   resources :users, only: [:index, :show, :edit, :update, :destroy]
 

--- a/db/migrate/20180825124726_add_omniauth_to_users.rb
+++ b/db/migrate/20180825124726_add_omniauth_to_users.rb
@@ -1,0 +1,6 @@
+class AddOmniauthToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :surveymonkey_token, :string
+    add_column :users, :surveymonkey_uid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_27_132301) do
+ActiveRecord::Schema.define(version: 2018_08_25_124726) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -473,6 +473,8 @@ ActiveRecord::Schema.define(version: 2018_07_27_132301) do
     t.datetime "direct_otp_sent_at"
     t.datetime "totp_timestamp"
     t.boolean "two_factor_auth", default: false
+    t.string "surveymonkey_token"
+    t.string "surveymonkey_uid"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["encrypted_otp_secret_key"], name: "index_users_on_encrypted_otp_secret_key", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -4,7 +4,9 @@ class UserTest < ActiveSupport::TestCase
   setup do
     @user = User.new(
       email: 'user@example.com',
-      password: 'password'
+      password: 'password',
+      surveymonkey_uid: 'test_uid',
+      surveymonkey_token: 'test_token'
     )
   end
   
@@ -15,5 +17,27 @@ class UserTest < ActiveSupport::TestCase
   test "should generate an OTP secret key for two factor authentication" do
     @user.save
     assert @user.otp_secret_key.present?, "OTP secret key not generated."
+  end
+  
+  test "should respond to surveymonkey_uid" do
+    assert_equal "test_uid", @user.surveymonkey_uid
+  end
+  
+  test "should respond to surveymonkey_token" do
+    assert_equal "test_token", @user.surveymonkey_token
+  end
+
+  test "should respond with SurveyMonkey enabled" do
+    assert @user.surveymonkey?
+  end
+  
+  test "should respond with SurveyMonkey disable when token is missing" do
+    @user.surveymonkey_token = nil
+    refute @user.surveymonkey?
+  end
+  
+  test "should respond with SurveyMonkey disabled when uid is missing" do
+    @user.surveymonkey_uid = nil
+    refute @user.surveymonkey?
   end
 end


### PR DESCRIPTION
In order for users to interact with SurveyMonkey, their SurveyMonkey API
credentials will need to be acquired from SurveyMonkey via OAuth.  Each
user can register their SurveyMonkey account from their user profile
edit screen.