### PR TITLE
Add surveys admin pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,7 @@ gem 'reform'
 
 gem 'two_factor_authentication'
 gem 'rqrcode'
+gem 'ruby_http_client'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,6 +238,7 @@ GEM
     rqrcode (0.10.1)
       chunky_png (~> 1.0)
     ruby_dep (1.5.0)
+    ruby_http_client (3.3.0)
     sass (3.5.6)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -328,6 +329,7 @@ DEPENDENCIES
   reform-rails
   rollbar
   rqrcode
+  ruby_http_client
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   select2-rails

--- a/app/assets/javascripts/surveys.coffee
+++ b/app/assets/javascripts/surveys.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -1,0 +1,10 @@
+class SurveysController < ApplicationController
+  def index
+    @surveys = Survey.new(@current_user).find_all
+  end
+
+  def show
+    @survey = Survey.new(@current_user).find(params[:id])
+    @recipients = Survey.new(@current_user).recipients(params[:id])
+  end
+end

--- a/app/helpers/surveys_helper.rb
+++ b/app/helpers/surveys_helper.rb
@@ -1,0 +1,2 @@
+module SurveysHelper
+end

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -1,0 +1,54 @@
+class Survey
+  def initialize(user)
+    @user = user
+  end
+  
+  def find(id)
+    api.surveys._(id).get.parsed_body
+  end
+  
+  def find_all
+    api.
+      surveys.
+      get(
+        query_params: { include: "response_count"}
+      ).
+      parsed_body
+  end
+  
+  def recipients(id)
+    result = []
+    collectors(id).each do |collector|
+      result << api.
+        collectors.
+        _(collector[:id]).
+        recipients.
+        get(
+          query_params: { include: "survey_response_status,survey_link"}
+        ).
+        parsed_body[:data]
+    end
+    
+    result.flatten
+  end
+  
+  private
+  
+  def api
+    SendGrid::Client.new(
+      host: 'https://api.surveymonkey.com/v3', 
+      request_headers: {
+        'Authorization' => "Bearer #{bearer_token}", 
+        "Content-Type" => "application/json"
+      }
+    )
+  end
+  
+  def bearer_token
+    @user.surveymonkey_token
+  end
+  
+  def collectors(id)
+    api.surveys._(id).collectors.get.parsed_body[:data]
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,6 +54,9 @@
                       <li><%= link_to('Projects', projects_path) %></li>
                       <li><%= link_to('Reports', reports_path) %></li>
                       <li><%= link_to('Schools', schools_path) %></li>
+                      <% if current_user.surveymonkey? %>
+                        <li><%= link_to('Surveys', surveys_path) %></li>
+                      <% end %>
                       <li><%= link_to('Identities', identities_path) %></li>
                       <li><%= link_to('Talents', talents_path) %></li>
                       <li><%= link_to('Tasks', common_tasks_path) %></li>

--- a/app/views/surveys/index.html.erb
+++ b/app/views/surveys/index.html.erb
@@ -1,0 +1,25 @@
+<div class="page-header">
+  <h1>Listing surveys</h1>
+</div>
+
+<div class="table-responsive">
+  <table class="table table-striped table-bordered table-hover">
+    <thead>
+      <tr>
+        <th>Title</th>
+        <th>Responses</th>
+        <th></th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @surveys[:data].each do |survey| %>
+        <tr>
+          <td><%= survey[:title] %></td>
+          <td><%= survey[:response_count] %></td>
+          <td><%= link_to 'Show', survey_path(survey[:id]) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/surveys/show.html.erb
+++ b/app/views/surveys/show.html.erb
@@ -1,0 +1,49 @@
+<div class="page-header">
+  <%= link_to surveys_path, class: 'btn btn-default' do %>
+    <span class="glyphicon glyphicon-list-alt"></span>
+    Back
+  <% end %>
+  <h1>Show survey</h1>
+</div>
+
+<dl class="dl-horizontal text-left">
+  <dt>Title:</dt>
+  <dd><%= @survey[:title] %></dd>
+  
+  <dt>Response Count:</dt> 
+  <dd><%= @survey[:response_count] %></dd>
+  
+  <dt>Created:</dt> 
+  <dd><%= @survey[:date_created] %></dd>
+  
+  <dt>Modified:</dt> 
+  <dd><%= @survey[:date_modified] %></dd>
+  
+</dl>
+
+<h2>Recipients</h2>
+<div class="table-responsive">
+  <table class="table table-striped table-bordered table-hover">
+    <thead>
+      <tr>
+        <th>Email</th>
+        <th>Status</th>
+        <th></th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @recipients.each do |recipient| %>
+        <tr>
+          <td><%= recipient[:email] %></td>
+          <td><%= recipient[:survey_response_status].humanize %></td>
+          <td>
+            <% if recipient[:survey_response_status] == 'not_responded' %>
+              <%= link_to 'Fill out', recipient[:survey_link], target: '_blank' %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,5 +61,6 @@ Rails.application.routes.draw do
   resources :locations
   resources :organizations
   resources :participations, only: :destroy
+  resources :surveys, only: [:index, :show]
 
 end

--- a/test/controllers/surveys_controller_test.rb
+++ b/test/controllers/surveys_controller_test.rb
@@ -1,0 +1,101 @@
+require 'test_helper'
+
+class SurveysControllerTest < ActionController::TestCase
+  include Devise::Test::ControllerHelpers
+
+  setup do
+    sign_in users(:one)
+  end
+
+  test "should get index" do
+    survey = MiniTest::Mock.new
+    survey.expect :find_all, find_all_response
+    
+    Survey.stub :new, survey do
+      get :index
+      assert_response :success
+    end
+  end
+
+  test "should get show" do
+    survey = MiniTest::Mock.new
+    survey.expect :find, find_response, ['2222']
+    survey.expect :recipients, recipients_response, ['2222']
+    
+    Survey.stub :new, survey do
+      get :show, params: { id: '2222' }
+      assert_response :success
+    end
+  end
+
+  private
+  
+  def find_all_response
+    {
+      :per_page=>50, 
+      :total=>1, 
+      :data=>[
+        {
+          :response_count=>1, 
+          :href=>"https://api.surveymonkey.com/v3/surveys/156361936", 
+          :nickname=>"", 
+          :id=>"156361936", 
+          :title=>"Anthony's Test Survey"
+        }
+      ], 
+      :page=>1, 
+      :links=>{
+        :self=>"https://api.surveymonkey.net/v3/surveys?page=1&per_page=50"
+      }
+    }
+  end
+  
+  def find_response
+    {
+      :response_count=>1, 
+      :page_count=>1, 
+      :date_created=>"2018-08-17T13:10:00", 
+      :buttons_text=>{
+        :done_button=>"Done", 
+        :prev_button=>"Prev", 
+        :exit_button=>"", 
+        :next_button=>"Next"
+      }, 
+      :folder_id=>"1740371", 
+      :custom_variables=>{}, 
+      :nickname=>"", 
+      :id=>"156361936", 
+      :question_count=>2, 
+      :category=>"other", 
+      :preview=>"https://www.surveymonkey.com/r/Preview/?sm=xZUY_2BxPPqsF0RqmCIon32qARpLSfQmSLhFQ7_2Fb5bAiapXDoe4ZJh8_2BukqiH3OY5i", 
+      :is_owner=>true, 
+      :language=>"en", 
+      :footer=>true, 
+      :date_modified=>"2018-09-04T00:40:00", 
+      :analyze_url=>"https://www.surveymonkey.com/analyze/SZUKjwIqiyd6lBRcUyZC1_2Fd_2FBfSx13yYoV3csfey_2FbA_3D", 
+      :summary_url=>"https://www.surveymonkey.com/summary/SZUKjwIqiyd6lBRcUyZC1_2Fd_2FBfSx13yYoV3csfey_2FbA_3D", 
+      :href=>"https://api.surveymonkey.com/v3/surveys/156361936", 
+      :title=>"Anthony Test", 
+      :collect_url=>"https://www.surveymonkey.com/collect/list?sm=SZUKjwIqiyd6lBRcUyZC1_2Fd_2FBfSx13yYoV3csfey_2FbA_3D", 
+      :edit_url=>"https://www.surveymonkey.com/create/?sm=SZUKjwIqiyd6lBRcUyZC1_2Fd_2FBfSx13yYoV3csfey_2FbA_3D"
+    }
+  end
+  
+  def recipients_response
+    [
+      {
+        :survey_response_status=>"completely_responded", 
+        :href=>"https://api.surveymonkey.com/v3/collectors/21541045/recipients/407284707", 
+        :id=>"407278707", 
+        :survey_link=>"https://www.surveymonkey.com/r/?sm=bor3i1iYLtpH_2Fl71tcgzRQ_3D_3D", 
+        :email=>"example@gmail.com"
+      }, {
+        :survey_response_status=>"not_responded", 
+        :href=>"https://api.surveymonkey.com/v3/collectors/21540445/recipients/407274708", 
+        :id=>"407278408", 
+        :survey_link=>"https://www.surveymonkey.com/r/?sm=Yec3dRDakLgcm3M75_2FbTwA_3D_3D", 
+        :email=>"example2@gmail.com"
+      }
+    ]
+  end
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,8 +1,8 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
- email: one@test.com
- admin: true
+  email: one@test.com
+  admin: true
 
 two: 
   email: two@test.com
@@ -20,3 +20,15 @@ task_user:
 dashboard_user:
   email: dashboard_user@test.com
   admin: true
+
+survey_user:
+  email: survey_user@test.com
+  admin: true
+  encrypted_password: <%= User.new.send(:password_digest, 'password') %>
+  surveymonkey_token: token
+  surveymonkey_uid: uid
+  
+non_survey_user:
+  email: non_survey_user@test.com
+  admin: true
+  encrypted_password: <%= User.new.send(:password_digest, 'password') %>

--- a/test/integration/application_layout_test.rb
+++ b/test/integration/application_layout_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class ApplicationLayoutTest < ActionDispatch::IntegrationTest
+  test "Surveys link should not show when logged out" do
+    get new_user_session_path
+    assert_select "a", { text: "Surveys", count: 0 }
+  end
+  
+  test "Surveys link shows for registered SurveyMonkey users" do
+    post user_session_path, params: {
+      user: {
+        email: users(:survey_user).email,
+        password: 'password'
+      }
+    }
+    follow_redirect!
+    
+    assert_select "a", { text: "Surveys", count: 1 }
+  end
+  
+  test "Surveys link does not show for non-SurveyMonkey users" do
+    post user_session_path, params: {
+      user: {
+        email: users(:non_survey_user).email,
+        password: 'password'
+      }
+    }
+    follow_redirect!
+    
+    assert_select "a", { text: "Surveys", count: 0 }
+  end
+end


### PR DESCRIPTION
SurveyMonkey surveys do not show the link for recipients to fill out
surveys.  In order for survey's to be filled out by Ed on behalf of
students and the response be linked to the student, Ed will need the
link specific to the student so they can fill out their survey.  The
survey admin section allows users to see the surveys and fill out ones
that have not been filled out yet.