### PR TITLE
Add ability to create survey recipients

### DIFF
--- a/app/controllers/concerns/member_search.rb
+++ b/app/controllers/concerns/member_search.rb
@@ -1,0 +1,65 @@
+module MemberSearch
+  extend ActiveSupport::Concern
+  
+  #Filters
+  def filtered_members
+    members = Member.includes(:identity).order(:first_name, :last_name)
+
+    if params[:identity_ids].present?
+      members = Member.
+      joins(:identity).
+      where(identities: {id: params[:identity_ids]})
+    end
+
+    # Include cohorts to prevent n+1
+    if params[:include] == 'cohorts'
+      members = members.includes(:cohorts)
+    end
+
+    # limit the size of xml_http_request? responses
+    if request.xhr?
+      members = members.limit(25)
+    end
+
+    # Filter members by search term
+    if params[:q].present?
+      query = params[:q]
+      if request.xhr?
+        query = query[:term]
+      end
+      members = members.search_by_full_name(query)
+    end
+
+    # Filter members by school.
+    if params[:school_ids].present?
+      members = members.where(school_id: params[:school_ids])
+    end
+
+    # Filter members by organization.
+    if params[:organization_ids].present?
+      members = members.joins(:organizations).
+        where(organizations: { id: params[:organization_ids] })
+    end
+
+    # Filter members by neighborhood.
+    if params[:neighborhood_ids].present?
+      members = members.joins(:neighborhoods).
+        where(neighborhoods: { id: params[:neighborhood_ids] })
+    end
+
+    # Filter members by graduating class.
+    if params[:graduating_class_ids].present?
+      members = members.
+        where(graduating_class: params[:graduating_class_ids])
+    end
+
+    # Filter members by cohort.
+    if params[:cohort_ids].present?
+      members = members.
+        joins(:cohortians).
+        where(cohortians: {cohort_id: params[:cohort_ids]})
+    end
+
+    members
+  end
+end

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -1,4 +1,6 @@
 class MembersController < ApplicationController
+  include MemberSearch
+  
   before_action :set_member, only: [:show, :edit, :update, :destroy]
   load_and_authorize_resource
 
@@ -88,68 +90,6 @@ class MembersController < ApplicationController
     # Use callbacks to share common setup or constraints between actions.
     def set_member
       @member = Member.find(params[:id])
-    end
-
-    #Filters
-    def filtered_members
-      members = Member.includes(:identity).order(:first_name, :last_name)
-
-      if params[:identity_ids].present?
-        members = Member.
-        joins(:identity).
-        where(identities: {id: params[:identity_ids]})
-      end
-
-      # Include cohorts to prevent n+1
-      if params[:include] == 'cohorts'
-        members = members.includes(:cohorts)
-      end
-
-      # limit the size of xml_http_request? responses
-      if request.xhr?
-        members = members.limit(25)
-      end
-
-      # Filter members by search term
-      if params[:q].present?
-        query = params[:q]
-        if request.xhr?
-          query = query[:term]
-        end
-        members = members.search_by_full_name(query)
-      end
-
-      # Filter members by school.
-      if params[:school_ids].present?
-        members = members.where(school_id: params[:school_ids])
-      end
-
-      # Filter members by organization.
-      if params[:organization_ids].present?
-        members = members.joins(:organizations).
-          where(organizations: { id: params[:organization_ids] })
-      end
-
-      # Filter members by neighborhood.
-      if params[:neighborhood_ids].present?
-        members = members.joins(:neighborhoods).
-          where(neighborhoods: { id: params[:neighborhood_ids] })
-      end
-
-      # Filter members by graduating class.
-      if params[:graduating_class_ids].present?
-        members = members.
-          where(graduating_class: params[:graduating_class_ids])
-      end
-
-      # Filter members by cohort.
-      if params[:cohort_ids].present?
-        members = members.
-          joins(:cohortians).
-          where(cohortians: {cohort_id: params[:cohort_ids]})
-      end
-
-      members
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -1,4 +1,6 @@
 class SurveysController < ApplicationController
+  include MemberSearch
+  
   def index
     @surveys = Survey.new(@current_user).find_all
   end
@@ -6,5 +8,10 @@ class SurveysController < ApplicationController
   def show
     @survey = Survey.new(@current_user).find(params[:id])
     @recipients = Survey.new(@current_user).recipients(params[:id])
+  end
+  
+  def update
+    Survey.new(@current_user).add_recipients(params[:id], filtered_members)
+    redirect_to survey_path(params[:id])
   end
 end

--- a/app/helpers/members_helper.rb
+++ b/app/helpers/members_helper.rb
@@ -1,10 +1,17 @@
 module MembersHelper
-  def members_download_query_params
-    request.query_parameters.slice(:q,
+  def members_search_query_params
+    request.query_parameters.slice(
+      :q,
       :school_ids,
       :identity_ids,
       :organization_ids,
       :cohort_ids,
-      :graduating_class_ids)
+      :graduating_class_ids,
+      :neighborhood_ids
+    )
+  end
+  
+  def recipients_params(count)
+    members_search_query_params.merge(recipients: count)
   end
 end

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -126,6 +126,7 @@
 
 </div>
 
+<p class="text-right"><%= page_entries_info @members %></p>
 <div class="table-responsive">
   <table class="table table-striped table-bordered table-hover">
     <thead>
@@ -157,11 +158,19 @@
     </tbody>
   </table>
   <%= paginate @members %>
-  
+</div>
+
+<div class="page-footer">
   <div>
-    <%= link_to members_path({format: :csv}.merge(members_download_query_params)), class: 'btn btn-primary btn__download' do %>
+    <%= link_to members_path({format: :csv}.merge(members_search_query_params)), class: 'btn btn-primary btn__download' do %>
       <span class="glyphicon glyphicon-save"></span>
       Download
+    <% end %>
+    <% if current_user.surveymonkey? %>
+      <%= link_to surveys_path(recipients_params(@members.total_count)), class: 'btn btn-primary' do %>
+        <span class="glyphicon glyphicon-plus"></span>
+        Add to survey
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/surveys/index.html.erb
+++ b/app/views/surveys/index.html.erb
@@ -9,6 +9,9 @@
         <th>Title</th>
         <th>Responses</th>
         <th></th>
+        <% if params[:recipients].present? %>
+          <th></th>
+        <% end %>
       </tr>
     </thead>
 
@@ -18,6 +21,9 @@
           <td><%= survey[:title] %></td>
           <td><%= survey[:response_count] %></td>
           <td><%= link_to 'Show', survey_path(survey[:id]) %></td>
+          <% if params[:recipients].present? %>
+            <td><%= link_to "Add #{params[:recipients]} recipients", survey_path(survey[:id], recipients_params(params[:recipients])), method: :put %></td>
+          <% end %>
         </tr>
       <% end %>
     </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,6 @@ Rails.application.routes.draw do
   resources :locations
   resources :organizations
   resources :participations, only: :destroy
-  resources :surveys, only: [:index, :show]
+  resources :surveys, only: [:index, :show, :update]
 
 end

--- a/test/controllers/members_controller_test.rb
+++ b/test/controllers/members_controller_test.rb
@@ -319,5 +319,21 @@ class MembersControllerTest < ActionController::TestCase
     ability = Ability.new(user)
     assert ability.cannot? :delete, @member
   end
+  
+  test "should allow survey users to add recipients" do
+    sign_in users(:survey_user)
+    get :index
+    assert_response :success
+    
+    assert_select 'a', "Add to survey"
+  end
+  
+  test "should not allow non-survey users to add recipients" do
+    sign_in users(:non_survey_user)
+    get :index
+    assert_response :success
+    
+    assert_select 'a', { text: "Add to survey", count: 0 }
+  end
 
 end


### PR DESCRIPTION
The results of a search for members can now be added to a survey in
SurveyMonkey as recipients to an email collector.