### PR TITLE
Fix error from nil survey recipient

### DIFF
--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -57,7 +57,7 @@ class Survey
         parsed_body[:data]
     end
     
-    result.flatten
+    result.flatten.compact
   end
   
   private


### PR DESCRIPTION
There is a scenario where a collector with recipients returns a nil and
causes an error.  The nils are being removed to prevent the problem.