### PR TITLE
Add missing pagination for survey recipients

### DIFF
--- a/app/helpers/surveys_helper.rb
+++ b/app/helpers/surveys_helper.rb
@@ -1,2 +1,16 @@
 module SurveysHelper
+  def recipient_name(recipient)
+    if recipient[:last_name].present? || recipient[:first_name].present?
+      name = [recipient[:last_name], recipient[:first_name]].join(', ')
+    else
+      name = ""
+    end
+    
+    if recipient[:custom_fields].present?
+      member_id = recipient[:custom_fields][:"1"]
+      link_to name, member_path(member_id) 
+    else
+      name
+    end
+  end
 end

--- a/app/views/surveys/show.html.erb
+++ b/app/views/surveys/show.html.erb
@@ -26,6 +26,7 @@
   <table class="table table-striped table-bordered table-hover">
     <thead>
       <tr>
+        <th>Name</th>
         <th>Email</th>
         <th>Status</th>
         <th></th>
@@ -35,6 +36,7 @@
     <tbody>
       <% @recipients.each do |recipient| %>
         <tr>
+          <td><%= recipient_name(recipient) %></td>
           <td><%= recipient[:email] %></td>
           <td><%= recipient[:survey_response_status].humanize %></td>
           <td>


### PR DESCRIPTION
On the survey show page, only the first page of recipients where being
retrieved for each collector.  In the process of adding pagination, I
found out how to retrieve recipient names and added that to the
recipients listing to make it easier to use.