### PR TITLE
Fix two ETL problems

### DIFF
--- a/app/analytics/etl/dimensions/member.rb
+++ b/app/analytics/etl/dimensions/member.rb
@@ -1,6 +1,6 @@
 class Etl::Dimensions::Member
     def self.run
-        Member.all.each do |member|
+        ::Member.all.each do |member|
             attributes = {
                 member_id: member.id,
                 identity: member.identity.try(:name),

--- a/app/analytics/etl/facts/programming.rb
+++ b/app/analytics/etl/facts/programming.rb
@@ -37,11 +37,14 @@ class Etl::Facts::Programming
   end
 
   def self.hours(event)
-    hours = event.duration / 60.0
-    cohort_count = event.cohort_assignments.count
-
-    if cohort_count > 1
-      hours = hours * cohort_count
+    hours = 0
+    if event.duration.present?
+      hours = event.duration / 60.0
+      cohort_count = event.cohort_assignments.count
+  
+      if cohort_count > 1
+        hours = hours * cohort_count
+      end
     end
 
     hours


### PR DESCRIPTION
1) The member dimension and Member model where having name resolution
problems in development mode.  The Member model is now referenced from
the root of the names space using '::'.

2) The NetworkEvent#duration can be nil if the user clears the duration
field.  This resulted in an error during the ProgrammingFact ETL
calculating programming hours.