### PR TITLE
Fix duplicate checkins

### DIFF
--- a/app/controllers/check_ins_controller.rb
+++ b/app/controllers/check_ins_controller.rb
@@ -26,9 +26,11 @@ class CheckInsController < ApplicationController
     error_ids =[]
     member_ids.each do |member_id|
       participation_params = {member_id: member_id, network_event_id: network_event_id, level: level, participation_type: participation_type}
-      @participation = Participation.new(participation_params)
-      @participation.user = current_user
-      error_ids << member_id unless @participation.save
+      unless Participation.where(participation_params).exists?
+        @participation = Participation.new(participation_params)
+        @participation.user = current_user
+        error_ids << member_id unless @participation.save
+      end
     end
 
     respond_to do |format|

--- a/test/controllers/check_ins_controller_test.rb
+++ b/test/controllers/check_ins_controller_test.rb
@@ -20,9 +20,30 @@ class CheckInsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "should not create a duplicate participation during check in" do
+    assert_no_difference('Participation.count') do
+       post :create, params: { 
+         participation: { 
+           member_id: @participation.member_id, 
+           network_event_id: @participation.network_event_id, 
+           level: @participation.level 
+         }, 
+         network_event_id: @participation.network_event_id 
+       }, xhr: true
+    end
+    assert_response :success
+  end
+  
   test "should create participation during check in" do
     assert_difference('Participation.count') do
-       post :create, params: { participation: { member_id: @participation.member_id, network_event_id: @participation.network_event_id, level: @participation.level }, network_event_id: @participation.network_event_id }, xhr: true
+       post :create, params: { 
+         participation: { 
+           member_id: Member.where.not(id: @participation.member_id).first.id, 
+           network_event_id: @participation.network_event_id, 
+           level: @participation.level 
+         }, 
+         network_event_id: @participation.network_event_id 
+       }, xhr: true
     end
     assert_response :success
   end


### PR DESCRIPTION
The checkin page would allow the same member to be checked into an event
twice.  This would happen when more than one person was checking in
members to the event.