### PR TITLE
Fix Rack gem CVEs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,7 +180,7 @@ GEM
       heroics (~> 0.0.23)
       moneta (~> 0.8.1)
     puma (3.11.4)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
     rails (5.2.0)


### PR DESCRIPTION
CVE-2018-16471 - There is a possible XSS vulnerability in Rack before
2.0.6 and 1.6.11.

CVE-2018-16470 - There is a possible DoS vulnerability in the multipart
parser in Rack before 2.0.6.